### PR TITLE
Expose registry utilities via PageEditor #31

### DIFF
--- a/src/main/resources/assets/js/index.ts
+++ b/src/main/resources/assets/js/index.ts
@@ -1,5 +1,6 @@
 export {EditorEvent, EditorEvents} from './page-editor/event/EditorEvent';
 export {PageEditor} from './page-editor/PageEditor';
+export type {ComponentRecord, ComponentRecordType} from './page-editor/editor/types';
 
 // Compatibility exports
 export {ComponentPath} from '@enonic/lib-contentstudio/app/page/region/ComponentPath';

--- a/src/main/resources/assets/js/page-editor/PageEditor.ts
+++ b/src/main/resources/assets/js/page-editor/PageEditor.ts
@@ -50,6 +50,8 @@ import 'jquery';
 import 'jquery-ui/dist/jquery-ui.js';
 import {LiveEditPage} from './LiveEditPage';
 import {markComponentError, markComponentLoading, renderComponentHtml} from './componentRendering';
+import {getRecord, getRegistry} from './editor/stores/registry';
+import type {ComponentRecord} from './editor/types';
 import {EditorEvent, EditorEvents} from './event/EditorEvent';
 
 // ============================================================================
@@ -204,6 +206,14 @@ export class PageEditor {
 
     static reloadPage(): void {
         this.iframeEventBus?.fireEvent(new PageReloadRequestedEvent());
+    }
+
+    static getComponentAt(path: ComponentPath): ComponentRecord | undefined {
+        return getRecord(path?.toString());
+    }
+
+    static getAllComponents(): readonly ComponentRecord[] {
+        return Object.values(getRegistry());
     }
 
     static init(editMode: boolean): void {

--- a/src/main/resources/assets/js/page-editor/editor/adapter/reconcile.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/adapter/reconcile.tsx
@@ -27,7 +27,7 @@ function finalizeReconcile(current: Record<string, ComponentRecord>, records: Re
     Object.entries(records).forEach(([path, record]) => {
         const previous = current[path];
         if (previous?.loading) {
-            record.loading = true;
+            records[path] = {...record, loading: true};
         }
     });
 

--- a/src/main/resources/assets/js/page-editor/editor/types.ts
+++ b/src/main/resources/assets/js/page-editor/editor/types.ts
@@ -3,15 +3,15 @@ import type {ComponentPath} from '@enonic/lib-contentstudio/app/page/region/Comp
 export type ComponentRecordType = 'page' | 'region' | 'text' | 'part' | 'layout' | 'fragment';
 
 export interface ComponentRecord {
-    path: ComponentPath;
-    type: ComponentRecordType;
-    element: HTMLElement | undefined;
-    parentPath: string | undefined;
-    children: string[];
-    empty: boolean;
-    error: boolean;
-    descriptor: string | undefined;
-    loading: boolean;
+    readonly path: ComponentPath;
+    readonly type: ComponentRecordType;
+    readonly element: HTMLElement | undefined;
+    readonly parentPath: string | undefined;
+    readonly children: readonly string[];
+    readonly empty: boolean;
+    readonly error: boolean;
+    readonly descriptor: string | undefined;
+    readonly loading: boolean;
 }
 
 export interface ContextMenuState {


### PR DESCRIPTION
- Added `PageEditor.getComponentAt(path)` and `PageEditor.getAllComponents()` static accessors over the internal registry
- Exported `ComponentRecord` and `ComponentRecordType` types from the public API
- Marked `ComponentRecord` fields as `readonly`, including `children: readonly string[]`
- Replaced in-place mutation in `finalizeReconcile` with a fresh object spread to respect the new immutability contract

Closes #31

> This is patch improvement, exposing missing utilities to get components from path, required for correctly handling and checking them in CS to properly request updates and sync.
