### PR TITLE
Page Editor adjustments #33

### DIFF
--- a/.storybook/page-editor/overlay.stories.tsx
+++ b/.storybook/page-editor/overlay.stories.tsx
@@ -9,6 +9,7 @@ import {Lock} from 'lucide-preact';
 import {ComponentPlaceholder} from '../../src/main/resources/assets/js/page-editor/editor/components/placeholders/ComponentPlaceholder';
 import {ContextMenu} from '../../src/main/resources/assets/js/page-editor/editor/components/overlay/context-menu';
 import {DragPreview} from '../../src/main/resources/assets/js/page-editor/editor/components/overlay/DragPreview';
+import {PagePlaceholderCard} from '../../src/main/resources/assets/js/page-editor/editor/components/overlay/PagePlaceholderOverlay';
 import {setCurrentPageView} from '../../src/main/resources/assets/js/page-editor/editor/bridge';
 import {createPlaceholderIsland} from '../../src/main/resources/assets/js/page-editor/editor/rendering/placeholder-island';
 import type {ComponentRecord, ComponentRecordType} from '../../src/main/resources/assets/js/page-editor/editor/types';
@@ -315,5 +316,21 @@ export const ContextMenuText: Story = {
         <IslandMount style={{width: '520px', height: '360px', position: 'relative'}}>
             <ContextMenuTextScene />
         </IslandMount>
+    ),
+};
+
+//
+// * PagePlaceholder
+//
+
+export const PagePlaceholderStates: Story = {
+    name: 'PagePlaceholder / States',
+    parameters: {layout: 'fullscreen'},
+    render: () => (
+        <div className='pe-shell flex min-h-screen flex-col items-center justify-center gap-6 bg-surface-primary p-6'>
+            <PagePlaceholderCard hasControllers={false} />
+            <PagePlaceholderCard hasControllers={true} />
+            <PagePlaceholderCard hasControllers={true} contentTypeDisplayName='Article' />
+        </div>
     ),
 };

--- a/.storybook/page-editor/overlay.stories.tsx
+++ b/.storybook/page-editor/overlay.stories.tsx
@@ -1,6 +1,8 @@
 import type {Meta, StoryObj} from '@storybook/preact-vite';
 import {Action} from '@enonic/lib-admin-ui/ui/Action';
 import {ComponentPath} from '@enonic/lib-contentstudio/app/page/region/ComponentPath';
+import {PageState} from '@enonic/lib-contentstudio/app/wizard/page/PageState';
+import {TextComponentBuilder} from '@enonic/lib-contentstudio/app/page/region/TextComponent';
 import type {ComponentChildren, CSSProperties, JSX} from 'preact';
 import {useEffect, useLayoutEffect, useMemo, useRef, useState} from 'preact/hooks';
 import {Lock} from 'lucide-preact';
@@ -252,4 +254,66 @@ export const ContextMenuComponent: Story = {
 export const ContextMenuLocked: Story = {
     name: 'ContextMenu / Locked Page',
     render: () => <ContextMenuExample kind='locked-page' />,
+};
+
+//
+// * ContextMenu / Text snippet
+//
+
+const TEXT_SCENE_PATH = '/main/0';
+const TEXT_SCENE_TYPE: ComponentRecordType = 'text';
+const LONG_TEXT_HTML =
+    '<p>This is a <strong>text component</strong> body that is intentionally long enough to overflow the menu header so the snippet truncates with an ellipsis.</p>';
+
+const ContextMenuTextScene = (): JSX.Element => {
+    const portalRef = useRef<HTMLDivElement>(null);
+    const [portalContainer, setPortalContainer] = useState<HTMLElement | undefined>(undefined);
+
+    const actions = useMemo(() => createComponentActions(), []);
+
+    useLayoutEffect(() => {
+        if (portalRef.current != null) setPortalContainer(portalRef.current);
+    }, []);
+
+    useEffect(() => {
+        const textComponent = new TextComponentBuilder().setText(LONG_TEXT_HTML).build();
+        const original = PageState.getComponentByPath;
+        (PageState as unknown as {getComponentByPath: () => unknown}).getComponentByPath = () => textComponent;
+
+        mockPageViewWithActions(actions);
+        const cleanupRecord = seedRegistryRecord(TEXT_SCENE_PATH, TEXT_SCENE_TYPE);
+
+        return () => {
+            (PageState as unknown as {getComponentByPath: typeof original}).getComponentByPath = original;
+            closeContextMenu();
+            setCurrentPageView(undefined);
+            cleanupRecord();
+        };
+    }, [actions]);
+
+    const handleContextMenu = (event: MouseEvent): void => {
+        event.preventDefault();
+        event.stopPropagation();
+        openContextMenu({kind: 'component', path: TEXT_SCENE_PATH, x: event.clientX, y: event.clientY});
+    };
+
+    return (
+        <div className='pe-shell relative flex h-full w-full flex-col items-center justify-center gap-y-4'>
+            <p className='text-xs text-subtle'>Right-click the text component below to open the context menu</p>
+            <div onContextMenu={handleContextMenu} className='cursor-context-menu' style={{width: '280px'}}>
+                <ComponentPlaceholder type={TEXT_SCENE_TYPE} error={false} />
+            </div>
+            <div ref={portalRef} />
+            <ContextMenu portalContainer={portalContainer} />
+        </div>
+    );
+};
+
+export const ContextMenuText: Story = {
+    name: 'ContextMenu / Text Snippet',
+    render: () => (
+        <IslandMount style={{width: '520px', height: '360px', position: 'relative'}}>
+            <ContextMenuTextScene />
+        </IslandMount>
+    ),
 };

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -2,11 +2,19 @@ import jQuery from 'jquery';
 import {withThemeByClassName} from '@storybook/addon-themes';
 import type {Preview} from '@storybook/preact-vite';
 import {themes} from 'storybook/theming';
+import {Messages} from '@enonic/lib-admin-ui/util/Messages';
 
 import './storybook.css';
 
 globalThis.$ = jQuery;
 globalThis.jQuery = jQuery;
+
+Messages.setMessages({
+    'text.selectcontroller': 'Select a component to create a page',
+    'text.nocontrollers': 'No page controllers found',
+    'text.addapplications': 'Please add an application to your site to enable preview',
+    'text.notemplates': 'No page templates supporting content type "{0}" found',
+});
 
 const isDark = globalThis.matchMedia?.('(prefers-color-scheme: dark)').matches;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,7 +211,7 @@ packages:
     peerDependencies:
       '@dnd-kit/core': ^6.3.1
       '@dnd-kit/sortable': ^10.0.0
-      '@enonic/ui': ~0.47.6
+      '@enonic/ui': ~0.48.0
       '@radix-ui/react-slot': ^1.2.0
       focus-trap-react: ^11.0.0
       lucide-react: '>=0.500.0'
@@ -224,30 +224,6 @@ packages:
       '@enonic/lib-admin-ui': workspace:*
       '@radix-ui/react-slot': ^1.2.0
       focus-trap-react: ^11.0.0
-
-  '@enonic/ui@0.47.12':
-    resolution: {integrity: sha512-j/WEIP5KFeKCwEaWtFFxTKt1/pzT3DQH7bqUNBWn+xpZFu5Zl3Q5Xt6C34F8qtJqEndRsLSY4b50R9H5mCjC2A==}
-    engines: {node: '>=24.11.1', npm: '>=11.6.2', pnpm: '>=10.28.0'}
-    peerDependencies:
-      '@radix-ui/react-slot': ^1.2.0
-      focus-trap-react: ^11.0.0
-      lucide-react: '>=0.500.0'
-      preact: '>=10.0.0'
-      react: ^19.0.0
-      react-dom: ^19.0.0
-      react-virtuoso: ^4.0.0
-      tw-animate-css: ^1.0.0
-    peerDependenciesMeta:
-      preact:
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-      react-virtuoso:
-        optional: true
-      tw-animate-css:
-        optional: true
 
   '@enonic/ui@0.48.0':
     resolution: {integrity: sha512-W6yZjGMBLka4Hk5xb1FL6xeTG+ELJNX9XwT9T3+E8Isldy1rCjdHjYjNf9qX7YsDeHEmvwlourqAvXvITFCvbw==}
@@ -1958,6 +1934,11 @@ packages:
     engines: {node: ^18 || >=20}
     hasBin: true
 
+  nanoid@5.1.9:
+    resolution: {integrity: sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+
   nanostores@0.11.4:
     resolution: {integrity: sha512-k1oiVNN4hDK8NcNERSZLQiMfRzEGtfnvZvdBvey3SQbgn8Dcrk0h1I6vpxApjb10PFUflZrgJ2WEZyJQ+5v7YQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -2629,7 +2610,7 @@ snapshots:
       jquery-ui: 1.14.2
       lucide-react: 0.577.0(react@19.2.4)
       mousetrap: 1.6.5
-      nanoid: 5.1.7
+      nanoid: 5.1.9
       nanostores: 1.2.0
       preact: 10.29.1
       q: 1.5.1
@@ -2637,7 +2618,7 @@ snapshots:
   '@enonic/lib-contentstudio@file:.xp/dev/lib-contentstudio(1356bbdcb77451342c638b09d07a43e2)':
     dependencies:
       '@enonic/lib-admin-ui': file:.xp/dev/lib-admin-ui(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(@enonic/ui@0.48.0(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.1)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0))(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.1)
-      '@enonic/ui': 0.47.12(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.1)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
+      '@enonic/ui': 0.48.0(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.1)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)
       '@nanostores/preact': 1.1.0(nanostores@0.11.4)(preact@10.29.1)
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
       ckeditor4-react: 4.3.0(ckeditor4@4.25.1)(react@19.2.4)
@@ -2665,21 +2646,6 @@ snapshots:
       - ckeditor4
       - react
       - react-dom
-
-  '@enonic/ui@0.47.12(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.1)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)':
-    dependencies:
-      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
-      class-variance-authority: 0.7.1
-      clsx: 2.1.1
-      focus-trap-react: 11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      lucide-react: 0.577.0(react@19.2.4)
-      tailwind-merge: 3.4.1
-    optionalDependencies:
-      preact: 10.29.1
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      react-virtuoso: 4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      tw-animate-css: 1.4.0
 
   '@enonic/ui@0.48.0(@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4))(focus-trap-react@11.0.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(lucide-react@0.577.0(react@19.2.4))(preact@10.29.1)(react-dom@19.2.4(react@19.2.4))(react-virtuoso@4.18.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(tw-animate-css@1.4.0)':
     dependencies:
@@ -4307,6 +4273,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   nanoid@5.1.7: {}
+
+  nanoid@5.1.9: {}
 
   nanostores@0.11.4: {}
 

--- a/src/main/resources/assets/js/page-editor/ItemView.ts
+++ b/src/main/resources/assets/js/page-editor/ItemView.ts
@@ -5,7 +5,6 @@ import {Action} from '@enonic/lib-admin-ui/ui/Action';
 import {LoadMask} from '@enonic/lib-admin-ui/ui/mask/LoadMask';
 import {assertNotNull} from '@enonic/lib-admin-ui/util/Assert';
 import {i18n} from '@enonic/lib-admin-ui/util/Messages';
-
 import {ComponentPath} from '@enonic/lib-contentstudio/app/page/region/ComponentPath';
 import {AddComponentEvent} from '@enonic/lib-contentstudio/page-editor/event/outgoing/manipulation/AddComponentEvent';
 import {DeselectComponentEvent} from '@enonic/lib-contentstudio/page-editor/event/outgoing/navigation/DeselectComponentEvent';
@@ -116,6 +115,13 @@ export abstract class ItemView
     private contextMenuActions: Action[];
 
     public static LIVE_EDIT_SELECTED = 'live-edit-selected';
+
+    // ! lib-admin-ui's Action.setClass appends `-action` to whatever value it receives,
+    // so the stored class is `${PREFIX}-action`. Use the prefix when calling setClass and
+    // the full class when comparing against action.getClass().
+    public static SELECT_PARENT_ACTION_PREFIX = 'select-parent';
+
+    public static SELECT_PARENT_ACTION_CLASS = `${ItemView.SELECT_PARENT_ACTION_PREFIX}-action`;
 
     protected constructor(builder: ItemViewBuilder) {
         assertNotNull(builder.type, 'type cannot be null');
@@ -394,6 +400,8 @@ export abstract class ItemView
         const action = new Action(i18n('live.view.selectparent'));
 
         action.setSortOrder(0);
+        // Easy ID for "select parent" action, while they are still created in legacy code
+        action.setClass(ItemView.SELECT_PARENT_ACTION_PREFIX);
         action.onExecuted(() => {
             const parentView: ItemView = this.getParentItemView();
             if (parentView) {

--- a/src/main/resources/assets/js/page-editor/RegionView.ts
+++ b/src/main/resources/assets/js/page-editor/RegionView.ts
@@ -169,10 +169,12 @@ export class RegionView
     }
 
     registerComponentView(componentView: ComponentView, index?: number) {
-        if (this.componentViews.indexOf(componentView) === -1) { // do not register twice
+        if (this.componentViews.indexOf(componentView) === -1) {
             this.registerComponentViewInParent(componentView, index);
-            this.registerComponentViewListeners(componentView);
         }
+        // ComponentView constructor pre-inserts itself into componentViews when
+        // built with positionIndex, so don't skip listeners wiring
+        this.registerComponentViewListeners(componentView);
     }
 
     registerComponentViewInParent(componentView: ComponentView, index?: number): void {
@@ -185,7 +187,11 @@ export class RegionView
 
     registerComponentViewListeners(componentView: ComponentView): void {
         componentView.setParentItemView(this);
+
+        componentView.unItemViewAdded(this.itemViewAddedListener);
         componentView.onItemViewAdded(this.itemViewAddedListener);
+
+        componentView.unItemViewRemoved(this.itemViewRemovedListener);
         componentView.onItemViewRemoved(this.itemViewRemovedListener);
     }
 

--- a/src/main/resources/assets/js/page-editor/editor/adapter/bus-adapter.ts
+++ b/src/main/resources/assets/js/page-editor/editor/adapter/bus-adapter.ts
@@ -19,7 +19,7 @@ import {DeselectComponentEvent} from '@enonic/lib-contentstudio/page-editor/even
 import {SelectComponentEvent} from '@enonic/lib-contentstudio/page-editor/event/outgoing/navigation/SelectComponentEvent';
 import type {PageView} from '../../PageView';
 import {EditorEvent, EditorEvents} from '../../event/EditorEvent';
-import {selectLegacyItemView} from '../bridge';
+import {scrollLegacyItemViewIntoView, selectLegacyItemView} from '../bridge';
 import {$hoveredPath, $selectedPath, closeContextMenu, setHoveredPath, setLocked, setModifyAllowed, setSelectedPath} from '../stores/registry';
 import {markLoading, reconcilePage, reconcileSubtree, remapInteractionPath} from './reconcile';
 
@@ -177,7 +177,19 @@ export function registerBusHandlers(pageView: PageView): () => void {
     ComponentLoadedEvent.on(onLoaded);
     cleanup.push(() => ComponentLoadedEvent.un(onLoaded));
 
-    const onDuplicate = (event: DuplicateComponentViewEvent) => reconcileParentPath(event.getComponentPath());
+    const onDuplicate = (event: DuplicateComponentViewEvent) => {
+        const newComponentPath = event.getComponentPath();
+        const newPath = newComponentPath.toString();
+
+        reconcileParentPath(newComponentPath);
+
+        // Select the duplicated component after legacy DOM insert and reparse settle.
+        window.queueMicrotask(() => {
+            selectLegacyItemView(newPath);
+            scrollLegacyItemViewIntoView(newPath);
+            new SelectComponentEvent({path: newComponentPath, position: null}).fire();
+        });
+    };
     DuplicateComponentViewEvent.on(onDuplicate);
     cleanup.push(() => DuplicateComponentViewEvent.un(onDuplicate));
 

--- a/src/main/resources/assets/js/page-editor/editor/adapter/bus-adapter.ts
+++ b/src/main/resources/assets/js/page-editor/editor/adapter/bus-adapter.ts
@@ -19,6 +19,7 @@ import {DeselectComponentEvent} from '@enonic/lib-contentstudio/page-editor/even
 import {SelectComponentEvent} from '@enonic/lib-contentstudio/page-editor/event/outgoing/navigation/SelectComponentEvent';
 import type {PageView} from '../../PageView';
 import {EditorEvent, EditorEvents} from '../../event/EditorEvent';
+import {selectLegacyItemView} from '../bridge';
 import {$hoveredPath, $selectedPath, closeContextMenu, setHoveredPath, setLocked, setModifyAllowed, setSelectedPath} from '../stores/registry';
 import {markLoading, reconcilePage, reconcileSubtree, remapInteractionPath} from './reconcile';
 
@@ -136,17 +137,25 @@ export function registerBusHandlers(pageView: PageView): () => void {
     cleanup.push(() => RemoveComponentViewEvent.un(onRemove));
 
     const onMove = (event: MoveComponentViewEvent) => {
-        remapInteractionPath(event.getFrom().toString(), event.getTo().toString());
+        const toComponentPath = event.getTo();
+        const toPath = toComponentPath.toString();
+
+        remapInteractionPath(event.getFrom().toString(), toPath);
 
         const fromParent = event.getFrom().getParentPath()?.toString();
-        const toParent = event.getTo().getParentPath()?.toString();
+        const toParent = toComponentPath.getParentPath()?.toString();
         if (!fromParent || fromParent === toParent) {
             reconcilePath(fromParent);
-            return;
+        } else {
+            reconcilePath(fromParent);
+            reconcilePath(toParent);
         }
 
-        reconcilePath(fromParent);
-        reconcilePath(toParent);
+        // Re-select the moved component after legacy DOM move and reparse settle.
+        window.queueMicrotask(() => {
+            selectLegacyItemView(toPath);
+            new SelectComponentEvent({path: toComponentPath, position: null}).fire();
+        });
     };
     MoveComponentViewEvent.on(onMove);
     cleanup.push(() => MoveComponentViewEvent.un(onMove));

--- a/src/main/resources/assets/js/page-editor/editor/adapter/bus-adapter.ts
+++ b/src/main/resources/assets/js/page-editor/editor/adapter/bus-adapter.ts
@@ -1,5 +1,5 @@
 import {PageBuilder} from '@enonic/lib-contentstudio/app/page/Page';
-import type {ComponentPath} from '@enonic/lib-contentstudio/app/page/region/ComponentPath';
+import {ComponentPath} from '@enonic/lib-contentstudio/app/page/region/ComponentPath';
 import {PageState} from '@enonic/lib-contentstudio/app/wizard/page/PageState';
 import {ComponentLoadedEvent} from '@enonic/lib-contentstudio/page-editor/event/ComponentLoadedEvent';
 import {PageStateEvent} from '@enonic/lib-contentstudio/page-editor/event/incoming/common/PageStateEvent';
@@ -19,8 +19,12 @@ import {DeselectComponentEvent} from '@enonic/lib-contentstudio/page-editor/even
 import {SelectComponentEvent} from '@enonic/lib-contentstudio/page-editor/event/outgoing/navigation/SelectComponentEvent';
 import type {PageView} from '../../PageView';
 import {EditorEvent, EditorEvents} from '../../event/EditorEvent';
-import {closeContextMenu, setLocked, setModifyAllowed, setSelectedPath} from '../stores/registry';
+import {$hoveredPath, $selectedPath, closeContextMenu, setHoveredPath, setLocked, setModifyAllowed, setSelectedPath} from '../stores/registry';
 import {markLoading, reconcilePage, reconcileSubtree, remapInteractionPath} from './reconcile';
+
+function isPathOrDescendant(candidate: string | undefined, ancestor: string): boolean {
+    return candidate === ancestor || (candidate?.startsWith(`${ancestor}/`) ?? false);
+}
 
 export function registerBusHandlers(pageView: PageView): () => void {
     const cleanup: Array<() => void> = [];
@@ -113,7 +117,21 @@ export function registerBusHandlers(pageView: PageView): () => void {
     AddComponentViewEvent.on(onAdd);
     cleanup.push(() => AddComponentViewEvent.un(onAdd));
 
-    const onRemove = (event: RemoveComponentViewEvent) => reconcileParentPath(event.getComponentPath());
+    const onRemove = (event: RemoveComponentViewEvent) => {
+        const removedPath = event.getComponentPath().toString();
+
+        if (isPathOrDescendant($selectedPath.get(), removedPath)) {
+            setSelectedPath(undefined);
+            closeContextMenu();
+            new DeselectComponentEvent(ComponentPath.root()).fire();
+        }
+
+        if (isPathOrDescendant($hoveredPath.get(), removedPath)) {
+            setHoveredPath(undefined);
+        }
+
+        reconcileParentPath(event.getComponentPath());
+    };
     RemoveComponentViewEvent.on(onRemove);
     cleanup.push(() => RemoveComponentViewEvent.un(onRemove));
 

--- a/src/main/resources/assets/js/page-editor/editor/adapter/reconcile.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/adapter/reconcile.tsx
@@ -110,12 +110,17 @@ export function markError(path: string, error: boolean): void {
     updateRecord(path, {error});
 }
 
-export function remapInteractionPath(fromPath: string, toPath: string): void {
+export function remapInteractionPath(fromPath: string, toPath: string): string | undefined {
     const selected = $selectedPath.get();
     if (selected === fromPath) {
         setSelectedPath(toPath);
-    } else if (selected?.startsWith(`${fromPath}/`)) {
-        setSelectedPath(`${toPath}${selected.slice(fromPath.length)}`);
+        return toPath;
     }
+    if (selected?.startsWith(`${fromPath}/`)) {
+        const remapped = `${toPath}${selected.slice(fromPath.length)}`;
+        setSelectedPath(remapped);
+        return remapped;
+    }
+    return undefined;
 }
 

--- a/src/main/resources/assets/js/page-editor/editor/bridge.ts
+++ b/src/main/resources/assets/js/page-editor/editor/bridge.ts
@@ -1,7 +1,12 @@
 import type {Action} from '@enonic/lib-admin-ui/ui/Action';
 import type {PageView} from '../PageView';
 import type {ItemView} from '../ItemView';
+import {StringHelper} from '@enonic/lib-admin-ui/util/StringHelper';
 import {ComponentPath} from '@enonic/lib-contentstudio/app/page/region/ComponentPath';
+import {TextComponent} from '@enonic/lib-contentstudio/app/page/region/TextComponent';
+import {PageState} from '@enonic/lib-contentstudio/app/wizard/page/PageState';
+
+const TEXT_SNIPPET_MAX_LENGTH = 100;
 
 let currentPageView: PageView | undefined;
 
@@ -23,6 +28,30 @@ export function getActionsForPath(path: string): Action[] {
 
 export function getLegacyItemViewLabel(path: string): string | undefined {
     return resolveItemView(path)?.getName();
+}
+
+export function getComponentName(path: string): string | undefined {
+    const item = PageState.getComponentByPath(ComponentPath.fromString(path));
+    if (item == null) return undefined;
+
+    if (item instanceof TextComponent) {
+        const snippet = getTextSnippet(item);
+        if (snippet.length > 0) return snippet;
+    }
+
+    const named = item as {getName?: () => {toString(): string} | undefined};
+    const name = named.getName?.()?.toString();
+    return name != null && name.length > 0 ? name : undefined;
+}
+
+function getTextSnippet(component: TextComponent): string {
+    const text = StringHelper.htmlToString(component.getText() || '')
+        .replace(/\s+/g, ' ')
+        .trim();
+    const codepoints = Array.from(text);
+    return codepoints.length > TEXT_SNIPPET_MAX_LENGTH
+        ? codepoints.slice(0, TEXT_SNIPPET_MAX_LENGTH).join('')
+        : text;
 }
 
 export function getLockedPageActions(): Action[] {

--- a/src/main/resources/assets/js/page-editor/editor/bridge.ts
+++ b/src/main/resources/assets/js/page-editor/editor/bridge.ts
@@ -1,12 +1,14 @@
 import type {Action} from '@enonic/lib-admin-ui/ui/Action';
 import type {PageView} from '../PageView';
-import type {ItemView} from '../ItemView';
+import {ItemView} from '../ItemView';
 import {StringHelper} from '@enonic/lib-admin-ui/util/StringHelper';
 import {ComponentPath} from '@enonic/lib-contentstudio/app/page/region/ComponentPath';
 import {TextComponent} from '@enonic/lib-contentstudio/app/page/region/TextComponent';
 import {PageState} from '@enonic/lib-contentstudio/app/wizard/page/PageState';
 
 const TEXT_SNIPPET_MAX_LENGTH = 100;
+
+export const SELECT_PARENT_ACTION_CLASS = ItemView.SELECT_PARENT_ACTION_CLASS;
 
 let currentPageView: PageView | undefined;
 
@@ -24,6 +26,26 @@ export function resolveItemView(path: string): ItemView | undefined {
 
 export function getActionsForPath(path: string): Action[] {
     return resolveItemView(path)?.getContextMenuActions() ?? [];
+}
+
+export function getLegacyParentPath(path: string): string | undefined {
+    const parent = resolveItemView(path)?.getParentItemView();
+    return parent?.getPath().toString();
+}
+
+/**
+ * Aligns the legacy item's *top edge* with the viewport top (instantly) and
+ * returns its post-scroll bounding rect. Used by the new context menu's
+ * "Select parent" flow so the menu can be anchored to the parent's top without
+ * waiting for scrollend.
+ */
+export function focusLegacyItemViewInstant(path: string): DOMRect | undefined {
+    const itemView = resolveItemView(path);
+    if (!itemView) return undefined;
+
+    const element = itemView.getEl().getHTMLElement();
+    element.scrollIntoView({behavior: 'auto', block: 'start'});
+    return element.getBoundingClientRect();
 }
 
 export function getLegacyItemViewLabel(path: string): string | undefined {

--- a/src/main/resources/assets/js/page-editor/editor/components/OverlayApp.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/components/OverlayApp.tsx
@@ -8,6 +8,7 @@ import {DragPreview} from './overlay/DragPreview';
 import {DragTargetHighlighter} from './overlay/DragTargetHighlighter';
 import {Highlighter} from './overlay/Highlighter';
 import {PagePlaceholderOverlay} from './overlay/PagePlaceholderOverlay';
+import {ParentPulseHighlighter} from './overlay/ParentPulseHighlighter';
 import {SelectionHighlighter} from './overlay/SelectionHighlighter';
 import {Shader} from './overlay/Shader';
 
@@ -29,6 +30,7 @@ export const OverlayApp = (): JSX.Element => {
             <DragPreview />
             <Highlighter />
             <SelectionHighlighter />
+            <ParentPulseHighlighter />
             <Shader />
             <ContextMenu portalContainer={portalContainer} />
             <div ref={portalRef} />

--- a/src/main/resources/assets/js/page-editor/editor/components/overlay/PagePlaceholderOverlay.test.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/components/overlay/PagePlaceholderOverlay.test.tsx
@@ -1,48 +1,39 @@
 const pagePlaceholderMocks = vi.hoisted(() => ({
     loadPagePlaceholderState: vi.fn(),
-    selectedKeys: [] as string[],
     getCurrentPageView: vi.fn(),
+    i18n: vi.fn((key: string, ...args: unknown[]) => (args.length > 0 ? `${key}|${args.join(',')}` : key)),
 }));
 
 vi.mock('../../page-placeholder/load-page-placeholder', () => ({
     loadPagePlaceholderState: pagePlaceholderMocks.loadPagePlaceholderState,
 }));
 
-vi.mock('@enonic/lib-contentstudio/page-editor/event/outgoing/manipulation/SelectPageDescriptorEvent', () => ({
-    SelectPageDescriptorEvent: class {
-        private readonly key: string;
-
-        constructor(key: string) {
-            this.key = key;
-        }
-
-        fire(): void {
-            pagePlaceholderMocks.selectedKeys.push(this.key);
-        }
-    },
-}));
-
 vi.mock('../../bridge', () => ({
     getCurrentPageView: pagePlaceholderMocks.getCurrentPageView,
 }));
 
+vi.mock('@enonic/lib-admin-ui/util/Messages', () => ({
+    i18n: pagePlaceholderMocks.i18n,
+}));
+
 import {render} from 'preact';
 import {ComponentPath} from '@enonic/lib-contentstudio/app/page/region/ComponentPath';
-import {setModifyAllowed, setRegistry} from '../../stores/registry';
+import {setRegistry} from '../../stores/registry';
 import type {ComponentRecord} from '../../types';
 import {PagePlaceholderOverlay} from './PagePlaceholderOverlay';
 
-function makeRootRecord(type: ComponentRecord['type'], empty: boolean): ComponentRecord {
+function makeRootRecord(overrides: Partial<ComponentRecord> = {}): ComponentRecord {
     return {
         path: ComponentPath.root(),
-        type,
+        type: 'page',
         element: document.body,
         parentPath: undefined,
         children: [],
-        empty,
+        empty: true,
         error: false,
         descriptor: undefined,
         loading: false,
+        ...overrides,
     };
 }
 
@@ -72,12 +63,9 @@ describe('PagePlaceholderOverlay', () => {
 
         pagePlaceholderMocks.loadPagePlaceholderState.mockReset();
         pagePlaceholderMocks.loadPagePlaceholderState.mockResolvedValue({
-            loading: false,
-            error: undefined,
-            contentTypeDisplayName: 'Article',
-            options: [],
+            hasControllers: false,
+            contentTypeDisplayName: undefined,
         });
-        pagePlaceholderMocks.selectedKeys.length = 0;
         pagePlaceholderMocks.getCurrentPageView.mockReset();
         pagePlaceholderMocks.getCurrentPageView.mockReturnValue({
             getLiveEditParams: () => ({
@@ -86,10 +74,7 @@ describe('PagePlaceholderOverlay', () => {
             }),
         });
 
-        setModifyAllowed(true);
-        setRegistry({
-            '/': makeRootRecord('page', true),
-        });
+        setRegistry({'/': makeRootRecord()});
     });
 
     afterEach(() => {
@@ -97,55 +82,34 @@ describe('PagePlaceholderOverlay', () => {
         container.remove();
         document.body.innerHTML = '';
         setRegistry({});
-        setModifyAllowed(true);
     });
 
-    it('loads controller options and fires the selection event from the new overlay UI', async () => {
+    it('renders the legacy controller-available copy when descriptors load', async () => {
         pagePlaceholderMocks.loadPagePlaceholderState.mockResolvedValue({
-            loading: false,
-            error: undefined,
+            hasControllers: true,
             contentTypeDisplayName: 'Article',
-            options: [
-                {
-                    key: 'app:landing',
-                    displayName: 'Landing page',
-                    description: 'Best for curated editorial landing pages.',
-                },
-                {
-                    key: 'app:news',
-                    displayName: 'News page',
-                    description: 'Renders article content with the news application.',
-                },
-            ],
         });
 
         render(<PagePlaceholderOverlay />, container);
         await waitFor(() => pagePlaceholderMocks.loadPagePlaceholderState.mock.calls.length === 1);
-        await waitFor(() => container.textContent?.includes('Select a controller') ?? false);
+        await waitFor(() => container.textContent?.includes('text.selectcontroller') ?? false);
 
-        const select = container.querySelector('select') as HTMLSelectElement;
+        expect(container.textContent).toContain('text.selectcontroller');
+        expect(container.textContent).toContain('text.notemplates|Article');
+        expect(container.querySelector('select')).toBeNull();
+    });
 
-        expect(container.textContent).toContain('Select a controller');
-        expect(container.textContent).toContain('No page template is assigned for Article');
-        expect(select).not.toBeNull();
-        expect(Array.from(select.options).map((option) => option.textContent)).toEqual([
-            'Choose a controller',
-            'Landing page',
-            'News page',
-        ]);
+    it('also surfaces when the root page reports a render error', async () => {
+        setRegistry({'/': makeRootRecord({empty: false, error: true})});
 
-        select.value = 'app:news';
-        select.dispatchEvent(new Event('change', {bubbles: true}));
-        await flushEffects();
+        render(<PagePlaceholderOverlay />, container);
+        await waitFor(() => pagePlaceholderMocks.loadPagePlaceholderState.mock.calls.length === 1);
 
-        expect(pagePlaceholderMocks.selectedKeys).toEqual(['app:news']);
-        expect(container.textContent).toContain('Renders article content with the news application.');
+        expect(container.textContent).toContain('text.nocontrollers');
     });
 
     it('stays hidden when the root registry record is not an empty page shell', async () => {
-        setRegistry({
-            '/': makeRootRecord('part', true),
-        });
+        setRegistry({'/': makeRootRecord({type: 'part', empty: true})});
 
         render(<PagePlaceholderOverlay />, container);
         await flushEffects();

--- a/src/main/resources/assets/js/page-editor/editor/components/overlay/PagePlaceholderOverlay.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/components/overlay/PagePlaceholderOverlay.tsx
@@ -1,52 +1,58 @@
 import type {JSX} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
 import {ContentTypeName} from '@enonic/lib-admin-ui/schema/content/ContentTypeName';
-import {SelectPageDescriptorEvent} from '@enonic/lib-contentstudio/page-editor/event/outgoing/manipulation/SelectPageDescriptorEvent';
+import {DefaultErrorHandler} from '@enonic/lib-admin-ui/DefaultErrorHandler';
+import {i18n} from '@enonic/lib-admin-ui/util/Messages';
 import {ComponentPath} from '@enonic/lib-contentstudio/app/page/region/ComponentPath';
 import {getCurrentPageView} from '../../bridge';
 import {useStoreValue} from '../../hooks/use-store-value';
-import {$modifyAllowed, $registry} from '../../stores/registry';
+import {$registry} from '../../stores/registry';
 import {loadPagePlaceholderState, type PlaceholderState} from '../../page-placeholder/load-page-placeholder';
+
+const INITIAL_STATE: PlaceholderState = {
+    hasControllers: false,
+    contentTypeDisplayName: undefined,
+};
+
+export interface PagePlaceholderCardProps {
+    hasControllers: boolean;
+    contentTypeDisplayName?: string;
+}
+
+export function PagePlaceholderCard({hasControllers, contentTypeDisplayName}: PagePlaceholderCardProps): JSX.Element {
+    const headerKey = hasControllers ? 'text.selectcontroller' : 'text.nocontrollers';
+    const subText = !hasControllers
+        ? i18n('text.addapplications')
+        : contentTypeDisplayName
+            ? i18n('text.notemplates', contentTypeDisplayName)
+            : undefined;
+
+    return (
+        <div className='pe-shell pointer-events-auto w-full max-w-[560px] rounded-md border-2 border-dashed border-violet-500/50 p-6 text-center'>
+            <p className='text-xl font-semibold text-subtle'>{i18n(headerKey)}</p>
+            {subText ? <p className='mt-1 text-lg text-subtle'>{subText}</p> : null}
+        </div>
+    );
+}
 
 export function PagePlaceholderOverlay(): JSX.Element | null {
     const registry = useStoreValue($registry);
-    const modifyAllowed = useStoreValue($modifyAllowed);
     const pageView = getCurrentPageView();
     const rootRecord = registry[ComponentPath.root().toString()];
-    const isVisible = rootRecord?.type === 'page' && rootRecord.empty;
+    const isVisible = rootRecord?.type === 'page' && (rootRecord.empty || rootRecord.error);
     const liveEditParams = pageView?.getLiveEditParams();
     const contentType = liveEditParams?.contentType;
     const isPageTemplate = contentType ? new ContentTypeName(contentType).isPageTemplate() : false;
-    const [selectedKey, setSelectedKey] = useState('');
-    const [state, setState] = useState<PlaceholderState>({
-        loading: false,
-        error: undefined,
-        contentTypeDisplayName: undefined,
-        options: [],
-    });
+    const [state, setState] = useState<PlaceholderState>(INITIAL_STATE);
 
     useEffect(() => {
         if (!isVisible) {
-            setSelectedKey('');
-            setState({
-                loading: false,
-                error: undefined,
-                contentTypeDisplayName: undefined,
-                options: [],
-            });
+            setState(INITIAL_STATE);
             return;
         }
 
         let cancelled = false;
-
-        setSelectedKey('');
-        setState((current) => ({
-            ...current,
-            loading: true,
-            error: undefined,
-            contentTypeDisplayName: undefined,
-            options: [],
-        }));
+        setState(INITIAL_STATE);
 
         loadPagePlaceholderState(liveEditParams?.contentId, contentType, isPageTemplate)
             .then((nextState) => {
@@ -54,14 +60,10 @@ export function PagePlaceholderOverlay(): JSX.Element | null {
                     setState(nextState);
                 }
             })
-            .catch(() => {
+            .catch((reason) => {
                 if (!cancelled) {
-                    setState({
-                        loading: false,
-                        error: 'The editor could not load available page controllers.',
-                        contentTypeDisplayName: undefined,
-                        options: [],
-                    });
+                    DefaultErrorHandler.handle(reason);
+                    setState(INITIAL_STATE);
                 }
             });
 
@@ -74,90 +76,12 @@ export function PagePlaceholderOverlay(): JSX.Element | null {
         return null;
     }
 
-    const selectedOption = state.options.find((option) => option.key === selectedKey);
-
     return (
-        <div className='pointer-events-auto fixed inset-0 flex items-center justify-center p-6'>
-            <div className='pe-shell pe-card-shadow w-full max-w-[560px] rounded-[28px] border border-bdr-soft bg-surface-primary p-6'>
-                <div className='flex items-start gap-4'>
-                    <div className='flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-info/20 bg-info/10 text-xs font-semibold uppercase tracking-[0.24em] text-info'>
-                        Pg
-                    </div>
-                    <div className='min-w-0 flex-1'>
-                        <p className='text-sm font-semibold text-main'>
-                            {state.options.length > 0 ? 'Select a controller' : 'No page controller selected'}
-                        </p>
-                        <p className='mt-1 text-sm text-subtle'>
-                            {state.options.length > 0
-                                ? 'Choose how this content should be rendered inside the page editor.'
-                                : 'This page does not have a controller yet.'}
-                        </p>
-                    </div>
-                </div>
-
-                {state.loading ? (
-                    <div className='mt-5 animate-pulse rounded-[20px] border border-bdr-soft bg-surface-secondary/60 px-4 py-5 text-sm text-subtle'>
-                        Loading available controllers...
-                    </div>
-                ) : null}
-
-                {state.error ? (
-                    <div className='mt-5 rounded-[20px] border border-error/30 bg-error/8 px-4 py-4 text-sm text-main'>
-                        {state.error}
-                    </div>
-                ) : null}
-
-                {!state.loading && !state.error && state.options.length === 0 ? (
-                    <div className='mt-5 rounded-[20px] border border-bdr-soft bg-surface-secondary/60 px-4 py-5 text-sm text-subtle'>
-                        Install an application that contributes page controllers for this content type, then reload the editor.
-                    </div>
-                ) : null}
-
-                {!state.loading && !state.error && state.options.length > 0 ? (
-                    <div className='mt-5 space-y-3'>
-                        <label
-                            className='block text-xs font-semibold uppercase tracking-[0.18em] text-subtle'
-                            htmlFor='pe-page-controller-select'
-                        >
-                            Page controller
-                        </label>
-                        <select
-                            id='pe-page-controller-select'
-                            className='block w-full rounded-[16px] border border-bdr-soft bg-surface-primary px-4 py-3 text-sm text-main outline-none focus:border-info'
-                            disabled={!modifyAllowed}
-                            value={selectedKey}
-                            onChange={(event) => {
-                                const nextKey = (event.currentTarget as HTMLSelectElement).value;
-                                setSelectedKey(nextKey);
-
-                                if (nextKey) {
-                                    new SelectPageDescriptorEvent(nextKey).fire();
-                                }
-                            }}
-                        >
-                            <option value='' disabled>
-                                {modifyAllowed ? 'Choose a controller' : 'You do not have permission to change the controller'}
-                            </option>
-                            {state.options.map((option) => (
-                                <option key={option.key} value={option.key}>
-                                    {option.displayName}
-                                </option>
-                            ))}
-                        </select>
-
-                        <div className='rounded-[20px] border border-bdr-soft bg-surface-secondary/60 px-4 py-4'>
-                            <p className='text-sm text-main'>
-                                {selectedOption?.description || 'Pick a controller to render the page with the selected application.'}
-                            </p>
-                            {state.contentTypeDisplayName ? (
-                                <p className='mt-2 text-xs text-subtle'>
-                                    No page template is assigned for {state.contentTypeDisplayName}, so the controller choice will define the rendering.
-                                </p>
-                            ) : null}
-                        </div>
-                    </div>
-                ) : null}
-            </div>
+        <div className='pointer-events-none fixed inset-0 flex items-center justify-center p-6'>
+            <PagePlaceholderCard
+                hasControllers={state.hasControllers}
+                contentTypeDisplayName={state.contentTypeDisplayName}
+            />
         </div>
     );
 }

--- a/src/main/resources/assets/js/page-editor/editor/components/overlay/ParentPulseHighlighter.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/components/overlay/ParentPulseHighlighter.tsx
@@ -1,0 +1,28 @@
+import type {JSX} from 'preact';
+
+import {useStoreValue} from '../../hooks/use-store-value';
+import {useTrackedRect} from '../../hooks/use-tracked-rect';
+import {$dragState, $selectParentPulse} from '../../stores/registry';
+
+const PARENT_PULSE_HIGHLIGHTER_NAME = 'ParentPulseHighlighter';
+
+export const ParentPulseHighlighter = (): JSX.Element | null => {
+    const pulse = useStoreValue($selectParentPulse);
+    const dragState = useStoreValue($dragState);
+    const rect = useTrackedRect(pulse?.path);
+
+    if (dragState != null || pulse == null || rect == null) return null;
+
+    const {top, left, width, height} = rect;
+
+    return (
+        <div
+            data-component={PARENT_PULSE_HIGHLIGHTER_NAME}
+            key={pulse.key}
+            className='pe-parent-pulse pointer-events-none fixed z-30 rounded-xs'
+            style={{top, left, width, height}}
+        />
+    );
+};
+
+ParentPulseHighlighter.displayName = PARENT_PULSE_HIGHLIGHTER_NAME;

--- a/src/main/resources/assets/js/page-editor/editor/components/overlay/SelectionHighlighter.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/components/overlay/SelectionHighlighter.tsx
@@ -28,7 +28,7 @@ export const SelectionHighlighter = (): JSX.Element | null => {
                 y={top}
                 width={width}
                 height={height}
-                className='fill-bdr-select/8 stroke-bdr-select stroke-1'
+                className='fill-none stroke-bdr-select stroke-1'
             />
         </svg>
     );

--- a/src/main/resources/assets/js/page-editor/editor/components/overlay/context-menu/ActionItems.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/components/overlay/context-menu/ActionItems.tsx
@@ -1,11 +1,26 @@
 import {ContextMenu as UiContextMenu} from '@enonic/ui';
+import {ComponentPath} from '@enonic/lib-contentstudio/app/page/region/ComponentPath';
+import {SelectComponentEvent} from '@enonic/lib-contentstudio/page-editor/event/outgoing/navigation/SelectComponentEvent';
 import {Box, Columns2, PenLine, Puzzle} from 'lucide-preact';
 
 import type {Action} from '@enonic/lib-admin-ui/ui/Action';
 import type {LucideIcon} from 'lucide-preact';
 import type {JSX} from 'preact';
 
-import {closeContextMenu} from '../../../stores/registry';
+import {
+    SELECT_PARENT_ACTION_CLASS,
+    deselectLegacyItemView,
+    focusLegacyItemViewInstant,
+    getLegacyParentPath,
+    selectLegacyItemView,
+} from '../../../bridge';
+import {
+    $contextMenuState,
+    closeContextMenu,
+    openContextMenu,
+    pulseSelectParent,
+    setSelectedPath,
+} from '../../../stores/registry';
 
 const INSERT_ICONS: Record<string, LucideIcon> = {
     part: Box,
@@ -16,6 +31,8 @@ const INSERT_ICONS: Record<string, LucideIcon> = {
 
 const sortActions = (actions: Action[]): Action[] =>
     [...actions].sort((left, right) => left.getSortOrder() - right.getSortOrder());
+
+const ANCHOR_TOP_GAP = 4;
 
 const resolveIcon = (action: Action): LucideIcon | undefined => {
     const iconClass = action.getIconClass();
@@ -61,13 +78,58 @@ export const ActionItems = ({actions, portalContainer, onPointerDown}: ActionIte
 
                 const Icon = resolveIcon(action);
 
+                const isSelectParent = action.getClass() === SELECT_PARENT_ACTION_CLASS;
+
                 return (
                     <UiContextMenu.Item
                         key={label}
                         disabled={!action.isEnabled()}
-                        onSelect={() => {
-                            action.execute();
-                            closeContextMenu();
+                        onSelect={(event) => {
+                            const previous = $contextMenuState.get();
+                            const parentPath = isSelectParent && previous != null
+                                ? getLegacyParentPath(previous.path)
+                                : undefined;
+
+                            if (!isSelectParent || previous == null || parentPath == null) {
+                                action.execute();
+                                closeContextMenu();
+                                return;
+                            }
+
+                            // ! preventDefault stops Radix's auto-close after onSelect,
+                            // so the menu stays mounted while we re-target it at the parent.
+                            event.preventDefault();
+
+                            // ? Bypass the legacy `selectItemView` flow — its outgoing
+                            //   DeselectComponentEvent triggers closeContextMenu in the bus
+                            //   adapter, fighting our reopen. Drive the transition silently
+                            //   here and fire only the SelectComponentEvent that ContentStudio
+                            //   needs (which already arms the deselect-echo swallow).
+                            deselectLegacyItemView(previous.path);
+                            selectLegacyItemView(parentPath);
+                            setSelectedPath(parentPath);
+                            new SelectComponentEvent({
+                                path: ComponentPath.fromString(parentPath),
+                                position: null,
+                                rightClicked: true,
+                            }).fire();
+
+                            // Instant scroll brings the parent's top into view; anchor the
+                            // menu horizontally on the parent's center, 4px below its top.
+                            const rect = focusLegacyItemViewInstant(parentPath);
+                            const anchorX = rect != null ? rect.left + rect.width / 2 : previous.x;
+                            const anchorY = rect != null ? rect.top + ANCHOR_TOP_GAP : previous.y;
+
+                            openContextMenu({
+                                kind: 'component',
+                                path: parentPath,
+                                x: anchorX,
+                                y: anchorY,
+                                centerX: rect != null,
+                                bumpKey: (previous.bumpKey ?? 0) + 1,
+                            });
+
+                            pulseSelectParent(parentPath);
                         }}
                     >
                         {Icon ? (

--- a/src/main/resources/assets/js/page-editor/editor/components/overlay/context-menu/ContextMenu.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/components/overlay/context-menu/ContextMenu.tsx
@@ -4,7 +4,7 @@ import type {JSX} from 'preact';
 
 import {useStoreValue} from '../../../hooks/use-store-value';
 import {$contextMenuState, $dragState, closeContextMenu, getRecord} from '../../../stores/registry';
-import {getActionsForPath, getLockedPageActions} from '../../../bridge';
+import {getActionsForPath, getComponentName, getLockedPageActions} from '../../../bridge';
 
 import {ActionItems} from './ActionItems';
 import {MenuHeader} from './MenuHeader';
@@ -26,6 +26,7 @@ export const ContextMenu = ({portalContainer}: ContextMenuProps): JSX.Element | 
     if (actions.length === 0) return null;
 
     const record = state.kind === 'component' ? getRecord(state.path) : undefined;
+    const name = state.kind === 'component' ? getComponentName(state.path) : undefined;
 
     const handleOpenChange = (open: boolean): void => {
         if (!open) closeContextMenu();
@@ -42,11 +43,11 @@ export const ContextMenu = ({portalContainer}: ContextMenuProps): JSX.Element | 
             <PositionSetter x={state.x} y={state.y} />
             <UiContextMenu.Portal container={portalContainer}>
                 <UiContextMenu.Content
-                    className='pointer-events-auto z-50'
+                    className='pointer-events-auto z-50 max-w-60'
                     data-component={CONTEXT_MENU_NAME}
                     onPointerDown={stopPropagation}
                 >
-                    <MenuHeader kind={state.kind} type={record?.type} />
+                    <MenuHeader kind={state.kind} type={record?.type} name={name} />
                     <ActionItems
                         actions={actions}
                         portalContainer={portalContainer}

--- a/src/main/resources/assets/js/page-editor/editor/components/overlay/context-menu/ContextMenu.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/components/overlay/context-menu/ContextMenu.tsx
@@ -1,4 +1,5 @@
 import {ContextMenu as UiContextMenu} from '@enonic/ui';
+import {useRef} from 'preact/hooks';
 
 import type {JSX} from 'preact';
 
@@ -38,11 +39,24 @@ export const ContextMenu = ({portalContainer}: ContextMenuProps): JSX.Element | 
     // menu and dismisses before the item's onSelect can fire.
     const stopPropagation = (event: Event): void => event.stopPropagation();
 
+    // ! Re-key on bumpKey so each "Select parent" step remounts Content
+    // and replays the Radix open animation, signalling a new menu.
+    const contentKey = state.bumpKey ?? 0;
+    const contentRef = useRef<HTMLDivElement>(null);
+
     return (
         <UiContextMenu open onOpenChange={handleOpenChange}>
-            <PositionSetter x={state.x} y={state.y} />
+            <PositionSetter
+                key={contentKey}
+                x={state.x}
+                y={state.y}
+                centerX={state.centerX}
+                contentRef={contentRef}
+            />
             <UiContextMenu.Portal container={portalContainer}>
                 <UiContextMenu.Content
+                    ref={contentRef}
+                    key={contentKey}
                     className='pointer-events-auto z-50 max-w-60'
                     data-component={CONTEXT_MENU_NAME}
                     onPointerDown={stopPropagation}

--- a/src/main/resources/assets/js/page-editor/editor/components/overlay/context-menu/MenuHeader.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/components/overlay/context-menu/MenuHeader.tsx
@@ -19,14 +19,15 @@ const capitalize = (value: string): string => value.charAt(0).toUpperCase() + va
 export type MenuHeaderProps = {
     kind: 'component' | 'locked-page';
     type: ComponentRecordType | undefined;
+    name?: string;
 };
 
-export const MenuHeader = ({kind, type}: MenuHeaderProps): JSX.Element | null => {
+export const MenuHeader = ({kind, type, name}: MenuHeaderProps): JSX.Element | null => {
     if (kind === 'locked-page') {
         return (
-            <UiContextMenu.Label className='flex items-center gap-2 py-2 font-bold'>
-                <Lock className='size-4' strokeWidth={2} />
-                Locked
+            <UiContextMenu.Label className='flex w-full cursor-default items-center gap-2 py-2 font-bold'>
+                <Lock className='size-4 shrink-0' strokeWidth={2} />
+                <span className='min-w-0 flex-1 truncate'>Locked</span>
             </UiContextMenu.Label>
         );
     }
@@ -37,9 +38,9 @@ export const MenuHeader = ({kind, type}: MenuHeaderProps): JSX.Element | null =>
     if (Icon == null) return null;
 
     return (
-        <UiContextMenu.Label className='flex items-center gap-2 py-2 font-bold'>
-            <Icon className='size-4' strokeWidth={2} />
-            {capitalize(type)}
+        <UiContextMenu.Label className='flex w-full cursor-default items-center gap-2 py-2 font-bold'>
+            <Icon className='size-4 shrink-0' strokeWidth={2} />
+            <span className='min-w-0 flex-1 truncate'>{name || capitalize(type)}</span>
         </UiContextMenu.Label>
     );
 };

--- a/src/main/resources/assets/js/page-editor/editor/components/overlay/context-menu/MenuHeader.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/components/overlay/context-menu/MenuHeader.tsx
@@ -1,5 +1,6 @@
+import {i18n} from '@enonic/lib-admin-ui/util/Messages';
 import {ContextMenu as UiContextMenu} from '@enonic/ui';
-import {Blocks, Box, Columns2, Lock, PenLine, Puzzle} from 'lucide-preact';
+import {Blocks, Box, Columns2, Globe, Lock, PenLine, Puzzle} from 'lucide-preact';
 
 import type {LucideIcon} from 'lucide-preact';
 import type {JSX} from 'preact';
@@ -7,6 +8,7 @@ import type {JSX} from 'preact';
 import type {ComponentRecordType} from '../../../types';
 
 const TYPE_ICONS: Partial<Record<ComponentRecordType, LucideIcon>> = {
+    page: Globe,
     region: Blocks,
     text: PenLine,
     part: Box,
@@ -37,10 +39,12 @@ export const MenuHeader = ({kind, type, name}: MenuHeaderProps): JSX.Element | n
     const Icon = TYPE_ICONS[type];
     if (Icon == null) return null;
 
+    const label = type === 'page' ? i18n('field.page') : (name || capitalize(type));
+
     return (
         <UiContextMenu.Label className='flex w-full cursor-default items-center gap-2 py-2 font-bold'>
             <Icon className='size-4 shrink-0' strokeWidth={2} />
-            <span className='min-w-0 flex-1 truncate'>{name || capitalize(type)}</span>
+            <span className='min-w-0 flex-1 truncate'>{label}</span>
         </UiContextMenu.Label>
     );
 };

--- a/src/main/resources/assets/js/page-editor/editor/components/overlay/context-menu/PositionSetter.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/components/overlay/context-menu/PositionSetter.tsx
@@ -1,17 +1,28 @@
 import {useContextMenu} from '@enonic/ui';
 import {useLayoutEffect} from 'preact/hooks';
 
+import type {RefObject} from 'preact';
+
 export type PositionSetterProps = {
     x: number;
     y: number;
+    /** When true, `x` is the menu's horizontal center; we shift left by half the measured width. */
+    centerX?: boolean;
+    /** Ref to the rendered menu Content; required when `centerX` is true. */
+    contentRef?: RefObject<HTMLDivElement>;
 };
 
-export const PositionSetter = ({x, y}: PositionSetterProps): null => {
+export const PositionSetter = ({x, y, centerX, contentRef}: PositionSetterProps): null => {
     const {setPosition} = useContextMenu();
 
     useLayoutEffect(() => {
+        if (centerX && contentRef?.current) {
+            const halfWidth = contentRef.current.offsetWidth / 2;
+            setPosition({x: x - halfWidth, y});
+            return;
+        }
         setPosition({x, y});
-    }, [setPosition, x, y]);
+    }, [setPosition, x, y, centerX, contentRef]);
 
     return null;
 };

--- a/src/main/resources/assets/js/page-editor/editor/page-placeholder/load-page-placeholder.test.ts
+++ b/src/main/resources/assets/js/page-editor/editor/page-placeholder/load-page-placeholder.test.ts
@@ -1,11 +1,7 @@
 const loaderMocks = vi.hoisted(() => ({
-    descriptors: [] as Array<{
-        getKey(): {toString(): string};
-        getDisplayName(): {toString(): string};
-        getDescription(): {toString(): string};
-        getName(): {toString(): string};
-    }>,
+    descriptors: [] as Array<{getKey(): {toString(): string}}>,
     contentTypeDisplayName: 'Article',
+    handleErrors: [] as unknown[],
 }));
 
 vi.mock('@enonic/lib-contentstudio/app/resource/GetComponentDescriptorsRequest', () => ({
@@ -26,22 +22,25 @@ vi.mock('@enonic/lib-contentstudio/app/resource/GetComponentDescriptorsRequest',
 
 vi.mock('@enonic/lib-contentstudio/app/resource/GetContentTypeByNameRequest', () => ({
     GetContentTypeByNameRequest: class {
-        sendAndParse(): Promise<{getDisplayName(): string}> {
+        sendAndParse(): Promise<{getTitle(): string}> {
             return Promise.resolve({
-                getDisplayName: () => loaderMocks.contentTypeDisplayName,
+                getTitle: () => loaderMocks.contentTypeDisplayName,
             });
         }
     },
 }));
 
+vi.mock('@enonic/lib-admin-ui/DefaultErrorHandler', () => ({
+    DefaultErrorHandler: {
+        handle: (reason: unknown) => loaderMocks.handleErrors.push(reason),
+    },
+}));
+
 import {loadPagePlaceholderState} from './load-page-placeholder';
 
-function makeDescriptor(key: string, displayName: string, description: string) {
+function makeDescriptor(key: string) {
     return {
         getKey: () => ({toString: () => key}),
-        getDisplayName: () => ({toString: () => displayName}),
-        getDescription: () => ({toString: () => description}),
-        getName: () => ({toString: () => displayName}),
     };
 }
 
@@ -49,28 +48,37 @@ describe('loadPagePlaceholderState', () => {
     beforeEach(() => {
         loaderMocks.descriptors = [];
         loaderMocks.contentTypeDisplayName = 'Article';
+        loaderMocks.handleErrors = [];
     });
 
-    it('maps and sorts page controller descriptors for the new placeholder UI', async () => {
-        loaderMocks.descriptors = [
-            makeDescriptor('app:news', 'News page', 'Renders article content with the news application.'),
-            makeDescriptor('app:landing', 'Landing page', 'Best for curated editorial landing pages.'),
-        ];
+    it('reports the controller availability and resolved content type display name', async () => {
+        loaderMocks.descriptors = [makeDescriptor('app:landing'), makeDescriptor('app:news')];
 
         const state = await loadPagePlaceholderState('content-id', 'com.example:article', false);
 
-        expect(state).toMatchObject({
-            loading: false,
-            error: undefined,
-            contentTypeDisplayName: 'com.example:article',
+        expect(state).toEqual({
+            hasControllers: true,
+            contentTypeDisplayName: 'Article',
         });
-        expect(state.options.map((option) => option.displayName)).toEqual([
-            'Landing page',
-            'News page',
-        ]);
-        expect(state.options[1]).toMatchObject({
-            key: 'app:news',
-            description: 'Renders article content with the news application.',
+    });
+
+    it('reports no controllers and no content type display name when descriptor list is empty', async () => {
+        const state = await loadPagePlaceholderState('content-id', 'com.example:article', false);
+
+        expect(state).toEqual({
+            hasControllers: false,
+            contentTypeDisplayName: undefined,
+        });
+    });
+
+    it('omits the content type display name lookup for page templates', async () => {
+        loaderMocks.descriptors = [makeDescriptor('app:landing')];
+
+        const state = await loadPagePlaceholderState('content-id', 'com.example:article', true);
+
+        expect(state).toEqual({
+            hasControllers: true,
+            contentTypeDisplayName: undefined,
         });
     });
 });

--- a/src/main/resources/assets/js/page-editor/editor/page-placeholder/load-page-placeholder.ts
+++ b/src/main/resources/assets/js/page-editor/editor/page-placeholder/load-page-placeholder.ts
@@ -5,26 +5,15 @@ import {GetContentTypeByNameRequest} from '@enonic/lib-contentstudio/app/resourc
 import {GetComponentDescriptorsRequest} from '@enonic/lib-contentstudio/app/resource/GetComponentDescriptorsRequest';
 import {type ContentType} from '@enonic/lib-contentstudio/app/inputtype/schema/ContentType';
 import {ContentTypeName} from '@enonic/lib-admin-ui/schema/content/ContentTypeName';
-
-export interface ControllerOption {
-    key: string;
-    displayName: string;
-    description: string;
-}
+import {DefaultErrorHandler} from '@enonic/lib-admin-ui/DefaultErrorHandler';
 
 export interface PlaceholderState {
-    loading: boolean;
-    error: string | undefined;
+    hasControllers: boolean;
     contentTypeDisplayName: string | undefined;
-    options: ControllerOption[];
 }
 
 function toPromise<T>(value: PromiseLike<T>): Promise<T> {
     return Promise.resolve(value);
-}
-
-function sortOptions(options: ControllerOption[]): ControllerOption[] {
-    return [...options].sort((left, right) => left.displayName.localeCompare(right.displayName));
 }
 
 export async function loadPagePlaceholderState(
@@ -40,30 +29,22 @@ export async function loadPagePlaceholderState(
     }
 
     const descriptors = await toPromise(request.sendAndParse() as PromiseLike<Descriptor[]>);
-    const options = sortOptions(descriptors.map((descriptor) => ({
-        key: descriptor.getKey().toString(),
-        displayName: descriptor.getDisplayName()?.toString() || descriptor.getName()?.toString() || descriptor.getKey().toString(),
-        description: descriptor.getDescription()?.toString() || 'No description available for this controller.',
-    })));
+    const hasControllers = descriptors.length > 0;
 
     let contentTypeDisplayName: string | undefined;
-    if (!isPageTemplate && contentType && options.length > 0) {
+    if (hasControllers && !isPageTemplate && contentType) {
         const name = new ContentTypeName(contentType);
 
         try {
             const contentTypeDetails = await toPromise(
                 new GetContentTypeByNameRequest(name).sendAndParse() as PromiseLike<ContentType>,
             );
-            contentTypeDisplayName = contentTypeDetails.getTitle();
-        } catch {
+            contentTypeDisplayName = contentTypeDetails.getTitle() || name.toString();
+        } catch (reason) {
             contentTypeDisplayName = name.toString();
+            DefaultErrorHandler.handle(reason);
         }
     }
 
-    return {
-        loading: false,
-        error: undefined,
-        contentTypeDisplayName,
-        options,
-    };
+    return {hasControllers, contentTypeDisplayName};
 }

--- a/src/main/resources/assets/js/page-editor/editor/parse/parse-page.ts
+++ b/src/main/resources/assets/js/page-editor/editor/parse/parse-page.ts
@@ -189,7 +189,7 @@ function parseStandardPage(body: HTMLElement): Record<string, ComponentRecord> {
         parentPath: undefined,
         children,
         empty: children.length === 0,
-        error: false,
+        error: body.getAttribute(ERROR_ATTR) === 'true',
         descriptor: undefined,
         loading: false,
     };
@@ -209,7 +209,7 @@ function parseFragmentPage(body: HTMLElement): Record<string, ComponentRecord> {
             parentPath: undefined,
             children: [],
             empty: true,
-            error: false,
+            error: body.getAttribute(ERROR_ATTR) === 'true',
             descriptor: undefined,
             loading: false,
         };

--- a/src/main/resources/assets/js/page-editor/editor/rendering/overlay-host.ts
+++ b/src/main/resources/assets/js/page-editor/editor/rendering/overlay-host.ts
@@ -1,6 +1,7 @@
 import {render, type ComponentChildren} from 'preact';
 import {OVERLAY_HOST_ID, OVERLAY_ROOT_ATTR} from '../constants';
 import {injectEditorStyles} from './inject-styles';
+import {registerThemeHost, unregisterThemeHost} from './theme-sync';
 
 export interface OverlayHost {
     host: HTMLElement;
@@ -20,6 +21,7 @@ export function createOverlayHost(content: ComponentChildren): OverlayHost {
 
     const shadow = host.attachShadow({mode: 'open'});
     injectEditorStyles(shadow);
+    registerThemeHost(host);
 
     const mount = document.createElement('div');
     mount.setAttribute(OVERLAY_ROOT_ATTR, 'true');
@@ -31,6 +33,7 @@ export function createOverlayHost(content: ComponentChildren): OverlayHost {
         shadow,
         mount,
         unmount: () => {
+            unregisterThemeHost(host);
             render(null, mount);
             host.remove();
         },

--- a/src/main/resources/assets/js/page-editor/editor/rendering/pe-components.css
+++ b/src/main/resources/assets/js/page-editor/editor/rendering/pe-components.css
@@ -42,4 +42,20 @@
     .pe-dash-error {
         --_dash: var(--color-error);
     }
+
+    @keyframes pe-parent-pulse {
+        0% {
+            box-shadow: inset 0 0 0 0 transparent;
+        }
+        40% {
+            box-shadow: inset 0 0 16px 3px var(--color-bdr-select);
+        }
+        100% {
+            box-shadow: inset 0 0 0 0 transparent;
+        }
+    }
+
+    .pe-parent-pulse {
+        animation: pe-parent-pulse 750ms ease-out 1;
+    }
 }

--- a/src/main/resources/assets/js/page-editor/editor/rendering/placeholder-island.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/rendering/placeholder-island.tsx
@@ -1,6 +1,7 @@
 import {render, type ComponentChildren} from 'preact';
 import {PLACEHOLDER_HOST_ATTR} from '../constants';
 import {injectEditorStyles} from './inject-styles';
+import {registerThemeHost, unregisterThemeHost} from './theme-sync';
 import type {PlaceholderIsland} from '../types';
 
 export function createPlaceholderIsland(container: HTMLElement, content: ComponentChildren): PlaceholderIsland {
@@ -13,6 +14,7 @@ export function createPlaceholderIsland(container: HTMLElement, content: Compone
 
     const shadow = host.attachShadow({mode: 'open'});
     injectEditorStyles(shadow);
+    registerThemeHost(host);
 
     const mount = document.createElement('div');
     mount.style.height = '100%';
@@ -24,6 +26,7 @@ export function createPlaceholderIsland(container: HTMLElement, content: Compone
         host,
         shadow,
         unmount: () => {
+            unregisterThemeHost(host);
             render(null, mount);
             host.remove();
         },

--- a/src/main/resources/assets/js/page-editor/editor/rendering/theme-sync.ts
+++ b/src/main/resources/assets/js/page-editor/editor/rendering/theme-sync.ts
@@ -1,0 +1,39 @@
+// ? `:host(.dark)` activates the @enonic/ui dark token cascade inside the
+// shadow root; `<html>.dark` set by the host page does not pierce the
+// shadow boundary, so the class must live on every shadow host element.
+//
+// One matchMedia listener feeds a registry of hosts so that placeholder
+// islands (one shadow per placeholder) do not each spin up their own.
+
+const hosts = new Set<Element>();
+let media: MediaQueryList | undefined;
+
+function applyTheme(): void {
+    const isDark = media?.matches === true;
+    for (const host of hosts) {
+        host.classList.toggle('dark', isDark);
+    }
+}
+
+function subscribe(): void {
+    if (media != null) return;
+    media = window.matchMedia?.('(prefers-color-scheme: dark)');
+    media?.addEventListener('change', applyTheme);
+}
+
+function unsubscribe(): void {
+    if (media == null) return;
+    media.removeEventListener('change', applyTheme);
+    media = undefined;
+}
+
+export function registerThemeHost(host: Element): void {
+    hosts.add(host);
+    subscribe();
+    host.classList.toggle('dark', media?.matches === true);
+}
+
+export function unregisterThemeHost(host: Element): void {
+    hosts.delete(host);
+    if (hosts.size === 0) unsubscribe();
+}

--- a/src/main/resources/assets/js/page-editor/editor/stores/registry.ts
+++ b/src/main/resources/assets/js/page-editor/editor/stores/registry.ts
@@ -1,5 +1,5 @@
 import {atom, map} from 'nanostores';
-import type {ComponentRecord, ContextMenuState, DragState} from '../types';
+import type {ComponentRecord, ContextMenuState, DragState, SelectParentPulse} from '../types';
 
 export const $registry = map<Record<string, ComponentRecord>>({});
 export const $selectedPath = atom<string | undefined>(undefined);
@@ -8,6 +8,7 @@ export const $locked = atom(false);
 export const $modifyAllowed = atom(true);
 export const $dragState = atom<DragState | undefined>(undefined);
 export const $contextMenuState = atom<ContextMenuState | undefined>(undefined);
+export const $selectParentPulse = atom<SelectParentPulse | undefined>(undefined);
 
 export function getRegistry(): Record<string, ComponentRecord> {
     return $registry.get();
@@ -55,4 +56,9 @@ export function openContextMenu(state: ContextMenuState): void {
 
 export function closeContextMenu(): void {
     $contextMenuState.set(undefined);
+}
+
+export function pulseSelectParent(path: string): void {
+    const previous = $selectParentPulse.get();
+    $selectParentPulse.set({path, key: (previous?.key ?? 0) + 1});
 }

--- a/src/main/resources/assets/js/page-editor/editor/types.ts
+++ b/src/main/resources/assets/js/page-editor/editor/types.ts
@@ -19,6 +19,9 @@ export interface ContextMenuState {
     path: string;
     x: number;
     y: number;
+    /** When true, `x` is treated as the menu's horizontal center (menu shifts left by half its measured width). */
+    centerX?: boolean;
+    bumpKey?: number;
 }
 
 export interface DragState {
@@ -31,6 +34,11 @@ export interface DragState {
     placeholderElement: HTMLElement | undefined;
     x: number | undefined;
     y: number | undefined;
+}
+
+export interface SelectParentPulse {
+    path: string;
+    key: number;
 }
 
 export interface PlaceholderIsland {


### PR DESCRIPTION
Bulk fixes and improvements for various subtasks of #33.

- Fixed selection not reset after selected component removal
- Fixed selection not restored after component moved
- Fixed selection on duplication and added scroll into view
- Fixed consumer (CS) not getting updates after item is added to newly inserted layout/region
- Added system/browser theme sync with components in shadow root
- Added (broken since CS 5) context menu shown when parent is selected
- Different visual improvements to selection and context menu
- Simplified page placeholder component, removing new UI parts
- Adjusted new UI styles