### PR TITLE
SetModifyAllowedEvent missing from iframe bus class registry #51

### DIFF
--- a/src/main/resources/assets/js/page-editor/PageEditor.ts
+++ b/src/main/resources/assets/js/page-editor/PageEditor.ts
@@ -40,6 +40,7 @@ import {MoveComponentViewEvent} from '@enonic/lib-contentstudio/page-editor/even
 import {RemoveComponentViewEvent} from '@enonic/lib-contentstudio/page-editor/event/incoming/manipulation/RemoveComponentViewEvent';
 import {ResetComponentViewEvent} from '@enonic/lib-contentstudio/page-editor/event/incoming/manipulation/ResetComponentViewEvent';
 import {SetDraggableVisibleEvent} from '@enonic/lib-contentstudio/page-editor/event/incoming/manipulation/SetDraggableVisibleEvent';
+import {SetModifyAllowedEvent} from '@enonic/lib-contentstudio/page-editor/event/incoming/manipulation/SetModifyAllowedEvent';
 import {SetPageLockStateEvent} from '@enonic/lib-contentstudio/page-editor/event/incoming/manipulation/SetPageLockStateEvent';
 import {UpdateTextComponentViewEvent} from '@enonic/lib-contentstudio/page-editor/event/incoming/manipulation/UpdateTextComponentViewEvent';
 import {DeselectComponentViewEvent} from '@enonic/lib-contentstudio/page-editor/event/incoming/navigation/DeselectComponentViewEvent';
@@ -144,6 +145,7 @@ function initializeEventBus(): IframeEventBus {
     eventBus.registerClass('LiveEditParams', LiveEditParams);
     eventBus.registerClass('InitializeLiveEditEvent', InitializeLiveEditEvent);
     eventBus.registerClass('PageStateEvent', PageStateEvent);
+    eventBus.registerClass('SetModifyAllowedEvent', SetModifyAllowedEvent);
     eventBus.registerClass('SetPageLockStateEvent', SetPageLockStateEvent);
     eventBus.registerClass('IframeBeforeContentSavedEvent', IframeBeforeContentSavedEvent);
     eventBus.registerClass('CreateOrDestroyDraggableEvent', CreateOrDestroyDraggableEvent);


### PR DESCRIPTION
Registered `SetModifyAllowedEvent` on the iframe-side `IframeEventBus` class registry in `PageEditor.initializeEventBus`, next to `SetPageLockStateEvent`. Without the registration, the iframe reviver returned a plain object and the listener's `event.isModifyAllowed()` call threw `TypeError`, breaking any Content Studio flow that toggles `wizardPanel.setEnabled()` (Reset, Localize, etc.).

Closes #51

<sub>*Drafted with AI assistance*</sub>
