### PR TITLE
Migrate from ProjectContext to activeProject store #53

### DIFF
--- a/src/main/resources/assets/js/page-editor/LiveEditPage.ts
+++ b/src/main/resources/assets/js/page-editor/LiveEditPage.ts
@@ -41,7 +41,7 @@ import {IframeBeforeContentSavedEvent} from '@enonic/lib-contentstudio/app/event
 import {PageBuilder} from '@enonic/lib-contentstudio/app/page/Page';
 import {PageState} from '@enonic/lib-contentstudio/app/wizard/page/PageState';
 import {Project} from '@enonic/lib-contentstudio/app/settings/data/project/Project';
-import {ProjectContext} from '@enonic/lib-contentstudio/app/project/ProjectContext';
+import {setActiveProject} from '@enonic/lib-contentstudio/v6/features/store/activeProject.store';
 import {SessionStorageHelper} from '@enonic/lib-contentstudio/app/util/SessionStorageHelper';
 import type {ContentSummaryAndCompareStatus} from '@enonic/lib-contentstudio/app/content/ContentSummaryAndCompareStatus';
 import {initNewUi} from './editor/init';
@@ -111,7 +111,7 @@ export class LiveEditPage {
         Messages.addMessages(JSON.parse(CONFIG.getString('phrasesAsJson')) as object);
         AuthContext.init(Principal.fromJson(event.getUserJson()), event.getPrincipalsJson().map(Principal.fromJson));
 
-        ProjectContext.get().setProject(Project.fromJson(event.getProjectJson()));
+        setActiveProject(Project.fromJson(event.getProjectJson()));
         PageState.setState(event.getPageJson() ? new PageBuilder().fromJson(event.getPageJson()).build() : null);
 
         ContentContext.get().setContent(event.getContent());


### PR DESCRIPTION
Replaced the iframe's `ProjectContext` seeding in `LiveEditPage.init` with `setActiveProject` from the new `activeProject.store`. CS removed `ProjectContext` in `app-contentstudio` commit `11db99b75` ([Remove ProjectContext #10448](https://github.com/enonic/app-contentstudio/pull/10492)), so the import was about to break the build; the seed itself remains load-bearing because URL builders, `CmsProjectBasedResourceRequest`, fragment-detach (`GetContentByIdRequest`), component-descriptor lookup (`GetComponentDescriptorsRequest`), and `ProjectHelper` permission checks all read the active project from inside the iframe.

Closes #53

<sub>*Drafted with AI assistance*</sub>
