### PR TITLE
Restore transparent fill on selected element overlay #58

### DIFF
--- a/src/main/resources/assets/js/page-editor/editor/components/overlay/SelectionHighlighter.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/components/overlay/SelectionHighlighter.tsx
@@ -28,7 +28,7 @@ export const SelectionHighlighter = (): JSX.Element | null => {
                 y={top}
                 width={width}
                 height={height}
-                className='fill-none stroke-bdr-select stroke-1'
+                className='fill-bdr-select/8 stroke-bdr-select stroke-1'
             />
         </svg>
     );


### PR DESCRIPTION
Restored the transparent blue fill (`fill-bdr-select/8`) on the selection rect in `SelectionHighlighter` so the active element is visually distinct from the surrounding content, alongside the existing border.

Closes #58

<sub>*Drafted with AI assistance*</sub>
