### PR TITLE
Rework drag placeholder and preview visuals #60

### DIFF
--- a/.storybook/page-editor/overlay.stories.tsx
+++ b/.storybook/page-editor/overlay.stories.tsx
@@ -124,7 +124,11 @@ type Story = StoryObj<typeof meta>;
 //
 
 const DragPreviewExample = ({dropAllowed, label}: {dropAllowed: boolean; label: string}): JSX.Element => {
-    useEffect(() => {
+    const frameRef = useRef<HTMLDivElement | null>(null);
+
+    useLayoutEffect(() => {
+        if (!frameRef.current) return undefined;
+        const rect = frameRef.current.getBoundingClientRect();
         setDragState({
             itemType: 'part',
             itemLabel: label,
@@ -133,16 +137,18 @@ const DragPreviewExample = ({dropAllowed, label}: {dropAllowed: boolean; label: 
             dropAllowed,
             message: undefined,
             placeholderElement: undefined,
-            x: 200,
-            y: 160,
+            x: rect.left + rect.width / 2,
+            y: rect.top + rect.height / 2,
         });
         return () => setDragState(undefined);
     }, [dropAllowed, label]);
 
     return (
-        <IslandMount style={{width: '480px', height: '240px', position: 'relative'}}>
-            <DragPreview />
-        </IslandMount>
+        <div ref={frameRef} style={{width: '480px', height: '240px', position: 'relative'}}>
+            <IslandMount style={{width: '100%', height: '100%'}}>
+                <DragPreview />
+            </IslandMount>
+        </div>
     );
 };
 

--- a/.storybook/page-editor/placeholders.stories.tsx
+++ b/.storybook/page-editor/placeholders.stories.tsx
@@ -2,7 +2,6 @@ import type {Meta, StoryObj} from '@storybook/preact-vite';
 import type {ComponentChildren} from 'preact';
 import {useEffect, useRef} from 'preact/hooks';
 import {ComponentPlaceholder} from '../../src/main/resources/assets/js/page-editor/editor/components/placeholders/ComponentPlaceholder';
-import {DragPlaceholder} from '../../src/main/resources/assets/js/page-editor/editor/components/placeholders/DragPlaceholder';
 import {EmptyPlaceholder} from '../../src/main/resources/assets/js/page-editor/editor/components/placeholders/EmptyPlaceholder';
 import {LoadingPlaceholder} from '../../src/main/resources/assets/js/page-editor/editor/components/placeholders/LoadingPlaceholder';
 import {RegionPlaceholder} from '../../src/main/resources/assets/js/page-editor/editor/components/placeholders/RegionPlaceholder';
@@ -57,28 +56,6 @@ export const DropzoneDefault: Story = {
     render: () => (
         <IslandMount className='w-160'>
             <RegionPlaceholder path='/main' regionName='main' />
-        </IslandMount>
-    ),
-};
-
-export const DropzoneDragOver: Story = {
-    name: 'Dropzone / Drag Over',
-    render: () => (
-        <IslandMount className='w-160'>
-            <DragPlaceholder itemLabel='Hero banner' dropAllowed={true} />
-        </IslandMount>
-    ),
-};
-
-export const DropzoneForbidden: Story = {
-    name: 'Dropzone / Forbidden',
-    render: () => (
-        <IslandMount className='w-160'>
-            <DragPlaceholder
-                itemLabel='Layout'
-                dropAllowed={false}
-                message='This is a message that describes the error'
-            />
         </IslandMount>
     ),
 };

--- a/src/main/resources/assets/js/page-editor/editor/components/overlay/DragPlaceholderPortal.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/components/overlay/DragPlaceholderPortal.tsx
@@ -12,23 +12,10 @@ export function DragPlaceholderPortal(): null {
             return undefined;
         }
 
-        const island = createPlaceholderIsland(
-            dragState.placeholderElement,
-            <DragPlaceholder
-                itemLabel={dragState.itemLabel}
-                dropAllowed={dragState.dropAllowed}
-                message={dragState.message}
-            />,
-        );
+        const island = createPlaceholderIsland(dragState.placeholderElement, <DragPlaceholder />);
 
         return () => island.unmount();
-    }, [
-        dragState?.placeholderElement,
-        dragState?.targetPath,
-        dragState?.itemLabel,
-        dragState?.dropAllowed,
-        dragState?.message,
-    ]);
+    }, [dragState?.placeholderElement, dragState?.targetPath]);
 
     return null;
 }

--- a/src/main/resources/assets/js/page-editor/editor/components/overlay/DragPreview.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/components/overlay/DragPreview.tsx
@@ -1,4 +1,5 @@
 import {FilledCircleCheck, FilledCircleX} from '@enonic/ui';
+import {useEffect, useState} from 'preact/hooks';
 
 import type {JSX} from 'preact';
 
@@ -9,8 +10,29 @@ import type {ComponentRecordType} from '../../types';
 
 const DRAG_PREVIEW_NAME = 'DragPreview';
 
+type Size = {width: number; height: number};
+
 export const DragPreview = (): JSX.Element | null => {
   const dragState = useStoreValue($dragState);
+  const placeholderElement = dragState?.placeholderElement;
+  const [size, setSize] = useState<Size | undefined>(undefined);
+
+  useEffect(() => {
+    if (!placeholderElement) {
+      setSize(undefined);
+      return undefined;
+    }
+
+    const update = (): void => {
+      const rect = placeholderElement.getBoundingClientRect();
+      setSize({width: Math.max(100, rect.width - 20), height: rect.height});
+    };
+    update();
+
+    const observer = new ResizeObserver(update);
+    observer.observe(placeholderElement);
+    return () => observer.disconnect();
+  }, [placeholderElement]);
 
   if (dragState == null || dragState.x == null || dragState.y == null) return null;
 
@@ -29,7 +51,12 @@ export const DragPreview = (): JSX.Element | null => {
         type={dragState.itemType as ComponentRecordType}
         error={false}
         bare
-        className='absolute w-70 -translate-x-1/2 -translate-y-1/2 rounded-xs border border-bdr-soft shadow-lg'
+        className={
+          size != null
+            ? 'absolute -translate-x-1/2 -translate-y-1/2 rounded-xs border border-bdr-soft shadow-lg transition-[width] duration-100 ease-out'
+            : 'absolute w-70 -translate-x-1/2 -translate-y-1/2 rounded-xs border border-bdr-soft shadow-lg transition-[width] duration-100 ease-out'
+        }
+        style={size != null ? {width: `${String(size.width)}px`} : undefined}
       />
       <span className='absolute -top-4.5 -left-6 size-7 shrink-0 drop-shadow-[0_0_2px_var(--color-surface-neutral)]'>
         <span className='absolute inset-[2.33px] rounded-full bg-surface-neutral' />

--- a/src/main/resources/assets/js/page-editor/editor/components/overlay/DragPreview.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/components/overlay/DragPreview.tsx
@@ -4,38 +4,43 @@ import type {JSX} from 'preact';
 
 import {useStoreValue} from '../../hooks/use-store-value';
 import {$dragState} from '../../stores/registry';
+import {ComponentPlaceholder} from '../placeholders/ComponentPlaceholder';
+import type {ComponentRecordType} from '../../types';
 
 const DRAG_PREVIEW_NAME = 'DragPreview';
 
 export const DragPreview = (): JSX.Element | null => {
-    const dragState = useStoreValue($dragState);
+  const dragState = useStoreValue($dragState);
 
-    if (dragState == null || dragState.x == null || dragState.y == null) return null;
+  if (dragState == null || dragState.x == null || dragState.y == null) return null;
 
-    const isAllowed = dragState.dropAllowed;
+  const isAllowed = dragState.dropAllowed;
 
-    return (
-        <div
-            data-component={DRAG_PREVIEW_NAME}
-            className='pointer-events-none fixed flex gap-4'
-            style={{
-                top: `${String(dragState.y - 28)}px`,
-                left: `${String(dragState.x - 24)}px`,
-            }}
-        >
-            <span className='relative mt-2.5 size-7 shrink-0'>
-                <span className='absolute inset-[2.33px] rounded-full bg-surface-neutral' />
-                {isAllowed ? (
-                    <FilledCircleCheck className='relative size-7 text-success' />
-                ) : (
-                    <FilledCircleX className='relative size-7 text-error' />
-                )}
-            </span>
-            <div className='rounded-lg border border-bdr-soft bg-surface-neutral px-7.5 py-4 leading-5.5 font-semibold whitespace-nowrap text-main shadow'>
-                {dragState.itemLabel}
-            </div>
-        </div>
-    );
+  return (
+    <div
+      data-component={DRAG_PREVIEW_NAME}
+      className='pointer-events-none fixed'
+      style={{
+        top: `${String(dragState.y)}px`,
+        left: `${String(dragState.x)}px`,
+      }}
+    >
+      <ComponentPlaceholder
+        type={dragState.itemType as ComponentRecordType}
+        error={false}
+        bare
+        className='absolute w-70 -translate-x-1/2 -translate-y-1/2 rounded-xs border border-bdr-soft shadow-lg'
+      />
+      <span className='absolute -top-4.5 -left-6 size-7 shrink-0 drop-shadow-[0_0_2px_var(--color-surface-neutral)]'>
+        <span className='absolute inset-[2.33px] rounded-full bg-surface-neutral' />
+        {isAllowed ? (
+          <FilledCircleCheck className='relative size-7 text-success' />
+        ) : (
+          <FilledCircleX className='relative size-7 text-error' />
+        )}
+      </span>
+    </div>
+  );
 };
 
 DragPreview.displayName = DRAG_PREVIEW_NAME;

--- a/src/main/resources/assets/js/page-editor/editor/components/placeholders/ComponentPlaceholder.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/components/placeholders/ComponentPlaceholder.tsx
@@ -9,6 +9,7 @@ export type ComponentPlaceholderProps = {
     type: ComponentRecordType;
     descriptor?: string;
     error: boolean;
+    bare?: boolean;
     className?: string;
 };
 
@@ -41,15 +42,20 @@ const WireframeLines = ({className}: WireframeLinesProps): JSX.Element => (
 // * Component
 //
 
-export const ComponentPlaceholder = ({type, descriptor, error, className}: ComponentPlaceholderProps): JSX.Element => {
+export const ComponentPlaceholder = ({type, descriptor, error, bare = false, className}: ComponentPlaceholderProps): JSX.Element => {
     if (error) {
         return (
             <div
                 data-component={COMPONENT_PLACEHOLDER_NAME}
                 className={cn('pe-shell overflow-hidden bg-surface-neutral select-none', className)}
             >
-                <div className='h-full p-2.5'>
-                    <div className='flex min-h-25 items-center justify-center border border-error px-4 py-2.5'>
+                <div className={cn('h-full', !bare && 'p-2.5')}>
+                    <div
+                        className={cn(
+                            'flex min-h-25 items-center justify-center px-4 py-2.5',
+                            !bare && 'border border-error',
+                        )}
+                    >
                         <p className='text-error'>
                             {descriptor || 'This component could not be rendered.'}
                         </p>
@@ -66,8 +72,13 @@ export const ComponentPlaceholder = ({type, descriptor, error, className}: Compo
             data-component={COMPONENT_PLACEHOLDER_NAME}
             className={cn('pe-shell @container overflow-hidden bg-surface-neutral select-none', className)}
         >
-            <div className='p-2.5'>
-                <div className='flex min-h-25 items-center justify-center border border-decorative p-2 @[12rem]:gap-4 @[12rem]:px-4 @[12rem]:py-2.5'>
+            <div className={cn(!bare && 'p-2.5')}>
+                <div
+                    className={cn(
+                        'flex min-h-25 items-center justify-center p-2 @[12rem]:gap-4 @[12rem]:px-4 @[12rem]:py-2.5',
+                        !bare && 'border border-decorative',
+                    )}
+                >
                     {Icon != null ? (
                         <div className='size-8 shrink-0 text-decorative @[12rem]:size-16'>
                             <Icon className='size-full' strokeWidth={1.5} />

--- a/src/main/resources/assets/js/page-editor/editor/components/placeholders/ComponentPlaceholder.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/components/placeholders/ComponentPlaceholder.tsx
@@ -3,7 +3,7 @@ import {Box, Columns2, PenLine, Puzzle} from 'lucide-preact';
 
 import type {ComponentRecordType} from '../../types';
 import type {LucideIcon} from 'lucide-preact';
-import type {JSX} from 'preact';
+import type {CSSProperties, JSX} from 'preact';
 
 export type ComponentPlaceholderProps = {
     type: ComponentRecordType;
@@ -11,6 +11,7 @@ export type ComponentPlaceholderProps = {
     error: boolean;
     bare?: boolean;
     className?: string;
+    style?: CSSProperties;
 };
 
 const COMPONENT_PLACEHOLDER_NAME = 'ComponentPlaceholder';
@@ -42,12 +43,13 @@ const WireframeLines = ({className}: WireframeLinesProps): JSX.Element => (
 // * Component
 //
 
-export const ComponentPlaceholder = ({type, descriptor, error, bare = false, className}: ComponentPlaceholderProps): JSX.Element => {
+export const ComponentPlaceholder = ({type, descriptor, error, bare = false, className, style}: ComponentPlaceholderProps): JSX.Element => {
     if (error) {
         return (
             <div
                 data-component={COMPONENT_PLACEHOLDER_NAME}
                 className={cn('pe-shell overflow-hidden bg-surface-neutral select-none', className)}
+                style={style}
             >
                 <div className={cn('h-full', !bare && 'p-2.5')}>
                     <div
@@ -71,6 +73,7 @@ export const ComponentPlaceholder = ({type, descriptor, error, bare = false, cla
         <div
             data-component={COMPONENT_PLACEHOLDER_NAME}
             className={cn('pe-shell @container overflow-hidden bg-surface-neutral select-none', className)}
+            style={style}
         >
             <div className={cn(!bare && 'p-2.5')}>
                 <div

--- a/src/main/resources/assets/js/page-editor/editor/components/placeholders/DragPlaceholder.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/components/placeholders/DragPlaceholder.tsx
@@ -3,34 +3,13 @@ import {cn} from '@enonic/ui';
 import type {JSX} from 'preact';
 
 export type DragPlaceholderProps = {
-    itemLabel: string;
-    dropAllowed: boolean;
-    message?: string;
     className?: string;
 };
 
 const DRAG_PLACEHOLDER_NAME = 'DragPlaceholder';
 
-export const DragPlaceholder = ({dropAllowed, message, className}: DragPlaceholderProps): JSX.Element => {
-    const text = dropAllowed ? 'Release here...' : (message ?? 'Cannot drop this component here.');
-
-    return (
-        <div
-            data-component={DRAG_PLACEHOLDER_NAME}
-            className={cn('pe-shell overflow-hidden bg-surface-neutral select-none', className)}
-        >
-            <div className='h-full p-2.5'>
-                <div
-                    className={cn(
-                        'pe-dash flex h-full min-h-25 items-center justify-center bg-surface-info/20 px-4 py-2.5 text-center',
-                        dropAllowed ? 'pe-dash-info text-subtle italic' : 'pe-dash-error text-error',
-                    )}
-                >
-                    {text}
-                </div>
-            </div>
-        </div>
-    );
+export const DragPlaceholder = ({className}: DragPlaceholderProps): JSX.Element => {
+    return <div data-component={DRAG_PLACEHOLDER_NAME} className={cn('min-h-30', className)} />;
 };
 
 DragPlaceholder.displayName = DRAG_PLACEHOLDER_NAME;

--- a/src/main/resources/assets/js/page-editor/editor/rendering/editor-ui.css
+++ b/src/main/resources/assets/js/page-editor/editor/rendering/editor-ui.css
@@ -18,6 +18,31 @@
     }
 
     /*
+     * ! Tailwind 4 box-shadow token reset
+     * Tailwind 4 ships `@property` rules that register the five `--tw-*-shadow`
+     * tokens with `inherits: false`, so under spec compliance an element's
+     * `shadow-*`/`ring-*` value cannot leak into its descendants. Inside a
+     * shadow root the registration is not always effective — the tokens fall
+     * back to ordinary custom-property semantics (inheriting), and a parent's
+     * `shadow-lg` (e.g. `ContextMenu.Content`) cascades into every descendant.
+     * Children that later compose `box-shadow` from those vars then paint the
+     * inherited soft shadow even when they own no `shadow-*` utility.
+     *
+     * Resetting per element with `:where(*)` keeps specificity at zero — any
+     * `shadow-*` / `ring-*` utility still wins on the element that declares
+     * it — while severing the inheritance path so descendants always start at
+     * `0 0 #0000`. This emulates the `inherits: false` semantics that
+     * `@property` is supposed to provide.
+     */
+    :where(*) {
+        --tw-shadow: 0 0 #0000;
+        --tw-inset-shadow: 0 0 #0000;
+        --tw-ring-shadow: 0 0 #0000;
+        --tw-inset-ring-shadow: 0 0 #0000;
+        --tw-ring-offset-shadow: 0 0 #0000;
+    }
+
+    /*
      * ! Shadow-DOM rem isolation
      * `rem` inside a shadow root always resolves against the document's
      * `<html>`, not `:host`. Host pages using the legacy 62.5% reset

--- a/src/main/resources/assets/js/page-editor/editor/rendering/pe-components.css
+++ b/src/main/resources/assets/js/page-editor/editor/rendering/pe-components.css
@@ -1,5 +1,5 @@
 @layer components {
-    /*
+  /*
      * ! Font isolation in shadow DOM
      * `:host` font rules lose to the embedding page's CSS targeting the host
      * element (e.g. `div { font-family: inherit }` in a host page stylesheet),
@@ -7,55 +7,53 @@
      * token on `.pe-shell` — which lives inside the shadow and is unreachable
      * from outer selectors — restores the UI font across the whole overlay.
      */
-    .pe-shell {
-        color: var(--color-main);
-        font-family: 'Open Sans', 'Segoe UI', sans-serif;
-        font-size: var(--text-base);
-    }
+  .pe-shell {
+    color: var(--color-main);
+    font-family: 'Open Sans', 'Segoe UI', sans-serif;
+    font-size: var(--text-base);
+  }
 
-    .pe-card-shadow {
-        box-shadow:
-            0 18px 42px -26px rgb(15 23 42 / 0.35),
-            0 8px 18px -14px rgb(15 23 42 / 0.22);
-    }
+  .pe-card-shadow {
+    box-shadow:
+      0 18px 42px -26px rgb(15 23 42 / 0.35),
+      0 8px 18px -14px rgb(15 23 42 / 0.22);
+  }
 
-    .pe-dash {
-        --_dash: var(--color-decorative);
-        background-image:
-            linear-gradient(90deg, var(--_dash) 50%, transparent 0),
-            linear-gradient(90deg, var(--_dash) 50%, transparent 0),
-            linear-gradient(0deg, var(--_dash) 50%, transparent 0),
-            linear-gradient(0deg, var(--_dash) 50%, transparent 0);
-        background-position: top, bottom, left, right;
-        background-repeat: repeat-x, repeat-x, repeat-y, repeat-y;
-        background-size:
-            22px 2px,
-            22px 2px,
-            2px 22px,
-            2px 22px;
-    }
+  .pe-dash {
+    --_dash: var(--color-decorative);
+    background-image:
+      linear-gradient(90deg, var(--_dash) 65%, transparent 0), linear-gradient(90deg, var(--_dash) 65%, transparent 0),
+      linear-gradient(0deg, var(--_dash) 65%, transparent 0), linear-gradient(0deg, var(--_dash) 65%, transparent 0);
+    background-position: top, bottom, left, right;
+    background-repeat: repeat-x, repeat-x, repeat-y, repeat-y;
+    background-size:
+      16px 1px,
+      16px 1px,
+      1px 16px,
+      1px 16px;
+  }
 
-    .pe-dash-info {
-        --_dash: var(--color-info);
-    }
+  .pe-dash-info {
+    --_dash: var(--color-info);
+  }
 
-    .pe-dash-error {
-        --_dash: var(--color-error);
-    }
+  .pe-dash-error {
+    --_dash: var(--color-error);
+  }
 
-    @keyframes pe-parent-pulse {
-        0% {
-            box-shadow: inset 0 0 0 0 transparent;
-        }
-        40% {
-            box-shadow: inset 0 0 16px 3px var(--color-bdr-select);
-        }
-        100% {
-            box-shadow: inset 0 0 0 0 transparent;
-        }
+  @keyframes pe-parent-pulse {
+    0% {
+      box-shadow: inset 0 0 0 0 transparent;
     }
+    40% {
+      box-shadow: inset 0 0 16px 3px var(--color-bdr-select);
+    }
+    100% {
+      box-shadow: inset 0 0 0 0 transparent;
+    }
+  }
 
-    .pe-parent-pulse {
-        animation: pe-parent-pulse 750ms ease-out 1;
-    }
+  .pe-parent-pulse {
+    animation: pe-parent-pulse 750ms ease-out 1;
+  }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import {defineConfig} from 'vite';
 import dts from 'vite-plugin-dts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url)) ?? '';
+const preactPath = path.join(__dirname, 'node_modules/preact');
 
 export default defineConfig(({mode}) => {
     const isProduction = mode === 'production';
@@ -87,11 +88,16 @@ export default defineConfig(({mode}) => {
             alias: {
                 '@enonic/lib-admin-ui': path.join(__dirname, '.xp/dev/lib-admin-ui'),
                 '@enonic/lib-contentstudio': path.join(__dirname, '.xp/dev/lib-contentstudio'),
-                'react': 'preact/compat',
-                'react-dom': 'preact/compat',
-                'react/jsx-runtime': 'preact/jsx-runtime',
-                'react/jsx-dev-runtime': 'preact/jsx-dev-runtime',
+                'react': path.join(preactPath, 'compat'),
+                'react-dom': path.join(preactPath, 'compat'),
+                'react/jsx-runtime': path.join(preactPath, 'jsx-runtime'),
+                'react/jsx-dev-runtime': path.join(preactPath, 'jsx-dev-runtime'),
             },
+            // ! Pinning every Preact entry to this project's node_modules keeps a
+            //   single instance when `@enonic/ui` is consumed via a `link:` override
+            //   (the linked package ships its own Preact). Two Preacts break hooks
+            //   with `TypeError: can't access property "__H", … is undefined`.
+            dedupe: ['preact', 'preact/compat', 'preact/hooks', 'preact/jsx-runtime', 'preact/jsx-dev-runtime'],
             extensions: ['.ts', '.tsx', '.js', '.jsx']
         },
         ...(isDevelopment && {


### PR DESCRIPTION
Reworked drag placeholder and preview visuals:

- `DragPlaceholder` reduced to an empty sized box (no text, border, or background).
- `DragPreview` redesigned: icon offset to top-left of cursor, block (`ComponentPlaceholder` with new `bare` prop) centered on cursor, `shadow-lg` drop shadow, surface-coloured halo around the icon.
- Drag preview block now mirrors the drop placeholder's width with a fast `transition-[width]` between targets. Width is `max(100, placeholder.width - 20)` to account for the typical 10px horizontal padding around components.
- Subtle `border-bdr-soft` outline on the preview block so it stays visible in dark themes where the shadow blends in.
- `.pe-dash` tightened to 1px lines with shorter dash/gap rhythm.
- Removed redundant `Dropzone / Drag Over` and `Dropzone / Forbidden` storybook stories.
- Centered the `DragPreview` story via `getBoundingClientRect`.

Closes #60

<sub>*Drafted with AI assistance*</sub>
