### PR TITLE
Empty placeholder appears next to existing part during reload #65

### DIFF
--- a/.storybook/page-editor/placeholders.stories.tsx
+++ b/.storybook/page-editor/placeholders.stories.tsx
@@ -3,6 +3,7 @@ import type {ComponentChildren} from 'preact';
 import {useEffect, useRef} from 'preact/hooks';
 import {ComponentPlaceholder} from '../../src/main/resources/assets/js/page-editor/editor/components/placeholders/ComponentPlaceholder';
 import {EmptyPlaceholder} from '../../src/main/resources/assets/js/page-editor/editor/components/placeholders/EmptyPlaceholder';
+import {LoadingOverlayPlaceholder} from '../../src/main/resources/assets/js/page-editor/editor/components/placeholders/LoadingOverlayPlaceholder';
 import {LoadingPlaceholder} from '../../src/main/resources/assets/js/page-editor/editor/components/placeholders/LoadingPlaceholder';
 import {RegionPlaceholder} from '../../src/main/resources/assets/js/page-editor/editor/components/placeholders/RegionPlaceholder';
 import {createPlaceholderIsland} from '../../src/main/resources/assets/js/page-editor/editor/rendering/placeholder-island';
@@ -14,9 +15,11 @@ import {createPlaceholderIsland} from '../../src/main/resources/assets/js/page-e
 interface IslandMountProps {
     children: ComponentChildren;
     className?: string;
+    overlay?: boolean;
+    underlay?: ComponentChildren;
 }
 
-function IslandMount({children, className}: IslandMountProps) {
+function IslandMount({children, className, overlay, underlay}: IslandMountProps) {
     const containerRef = useRef<HTMLDivElement | null>(null);
 
     useEffect(() => {
@@ -24,11 +27,11 @@ function IslandMount({children, className}: IslandMountProps) {
             return undefined;
         }
 
-        const island = createPlaceholderIsland(containerRef.current, children);
+        const island = createPlaceholderIsland(containerRef.current, children, {overlay});
         return () => island.unmount();
-    }, [children]);
+    }, [children, overlay]);
 
-    return <div ref={containerRef} className={className} />;
+    return <div ref={containerRef} className={className}>{underlay}</div>;
 }
 
 //
@@ -137,5 +140,32 @@ export const LoadingBlock: Story = {
         <IslandMount className='w-160'>
             <LoadingPlaceholder />
         </IslandMount>
+    ),
+};
+
+export const LoadingOverlay: Story = {
+    name: 'States / Loading Overlay',
+    render: () => (
+        <div className='flex flex-col items-center gap-y-3 p-4'>
+            <div className='max-w-120 text-sm text-subtle'>
+                Shown over a non-empty part while it is being reloaded — keeps the existing rendered
+                content visible behind a transparent shimmer until the new HTML arrives.
+            </div>
+            <IslandMount
+                className='w-160 rounded border border-decorative bg-surface-neutral p-6'
+                overlay
+                underlay={(
+                    <article>
+                        <h1 className='text-xl font-semibold'>Hero Banner</h1>
+                        <p className='mt-2 text-sm'>
+                            Existing rendered content stays visible underneath the shimmer overlay
+                            while the part configuration is being applied.
+                        </p>
+                    </article>
+                )}
+            >
+                <LoadingOverlayPlaceholder />
+            </IslandMount>
+        </div>
     ),
 };

--- a/src/main/resources/assets/js/page-editor/editor/adapter/placeholder-lifecycle.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/adapter/placeholder-lifecycle.tsx
@@ -1,4 +1,5 @@
 import {ComponentPlaceholder} from '../components/placeholders/ComponentPlaceholder';
+import {LoadingOverlayPlaceholder} from '../components/placeholders/LoadingOverlayPlaceholder';
 import {LoadingPlaceholder} from '../components/placeholders/LoadingPlaceholder';
 import {RegionPlaceholder} from '../components/placeholders/RegionPlaceholder';
 import {createPlaceholderIsland} from '../rendering/placeholder-island';
@@ -8,8 +9,13 @@ import type {ComponentRecord, DragState, PlaceholderIsland} from '../types';
 const placeholderIslands = new Map<string, PlaceholderIsland>();
 const placeholderKinds = new Map<string, string>();
 
+function isLoadingOverlay(record: ComponentRecord): boolean {
+    return Boolean(record.loading) && !record.error && !record.empty && record.type !== 'region';
+}
+
 function getPlaceholderKind(record: ComponentRecord): string {
     if (record.type === 'region') return 'region';
+    if (isLoadingOverlay(record)) return 'loading-overlay';
     if (record.loading && !record.error) return 'loading';
     return `component:${record.type}:${record.error ? '1' : '0'}:${record.descriptor ?? ''}`;
 }
@@ -68,13 +74,16 @@ export function syncPlaceholders(records: Record<string, ComponentRecord>): void
 
         destroyPlaceholder(path);
 
+        const overlay = isLoadingOverlay(record);
         const content = record.type === 'region'
             ? <RegionPlaceholder path={path} regionName={String(record.path.getPath())} />
-            : record.loading && !record.error
-                ? <LoadingPlaceholder />
-                : <ComponentPlaceholder type={record.type} descriptor={record.descriptor} error={record.error} />;
+            : overlay
+                ? <LoadingOverlayPlaceholder />
+                : record.loading && !record.error
+                    ? <LoadingPlaceholder />
+                    : <ComponentPlaceholder type={record.type} descriptor={record.descriptor} error={record.error} />;
 
-        placeholderIslands.set(path, createPlaceholderIsland(record.element, content));
+        placeholderIslands.set(path, createPlaceholderIsland(record.element, content, {overlay}));
         placeholderKinds.set(path, kind);
     });
 

--- a/src/main/resources/assets/js/page-editor/editor/adapter/reconcile.test.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/adapter/reconcile.test.tsx
@@ -5,7 +5,7 @@ vi.mock('@enonic/lib-contentstudio/app/wizard/page/PageState', () => ({
 }));
 
 import {destroyPlaceholders, initPlaceholderDragSync} from './placeholder-lifecycle';
-import {reconcilePage, reconcileSubtree} from './reconcile';
+import {markLoading, reconcilePage, reconcileSubtree} from './reconcile';
 import {PLACEHOLDER_HOST_ATTR} from '../constants';
 import {getRegistry, setDragState, setRegistry} from '../stores/registry';
 
@@ -139,6 +139,54 @@ describe('reconcilePage', () => {
             stopDragSync();
             setDragState(undefined);
         }
+    });
+
+    it('shows a loading overlay above a non-empty part while it is reloading', () => {
+        document.body.innerHTML = `
+            <section data-portal-region="main">
+                <article data-portal-component-type="part">
+                    <h1>Title</h1>
+                    <p>Body</p>
+                </article>
+            </section>
+        `;
+
+        reconcilePage(createPageView() as never);
+
+        const partEl = document.querySelector('article[data-portal-component-type="part"]') as HTMLElement;
+        expect(getRegistry()['/main/0'].empty).toBe(false);
+
+        markLoading('/main/0', true);
+
+        const overlay = partEl.querySelector(`[${PLACEHOLDER_HOST_ATTR}="overlay"]`) as HTMLElement | null;
+        expect(overlay).not.toBeNull();
+        expect(overlay?.style.position).toBe('absolute');
+        expect(overlay?.style.inset).toBe('0');
+        expect(partEl.style.position).toBe('relative');
+
+        markLoading('/main/0', false);
+
+        expect(partEl.querySelector(`[${PLACEHOLDER_HOST_ATTR}]`)).toBeNull();
+        expect(partEl.style.position).toBe('');
+    });
+
+    it('still shows a full-block loading placeholder while an empty part is loading', () => {
+        document.body.innerHTML = `
+            <section data-portal-region="main">
+                <article data-portal-component-type="part"></article>
+            </section>
+        `;
+
+        reconcilePage(createPageView() as never);
+        expect(getRegistry()['/main/0'].empty).toBe(true);
+
+        markLoading('/main/0', true);
+
+        const partEl = document.querySelector('article[data-portal-component-type="part"]') as HTMLElement;
+        const host = partEl.querySelector(`[${PLACEHOLDER_HOST_ATTR}]`) as HTMLElement | null;
+        expect(host).not.toBeNull();
+        expect(host?.getAttribute(PLACEHOLDER_HOST_ATTR)).toBe('true');
+        expect(host?.style.position).toBe('');
     });
 
     it('reconciles fragment pages against the root component path', () => {

--- a/src/main/resources/assets/js/page-editor/editor/components/placeholders/LoadingOverlayPlaceholder.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/components/placeholders/LoadingOverlayPlaceholder.tsx
@@ -1,4 +1,4 @@
-import {cn, Skeleton} from '@enonic/ui';
+import {cn} from '@enonic/ui';
 
 import type {JSX} from 'preact';
 
@@ -12,9 +12,12 @@ export const LoadingOverlayPlaceholder = ({className}: LoadingOverlayPlaceholder
     <div
         data-component={LOADING_OVERLAY_PLACEHOLDER_NAME}
         data-loading=''
-        className={cn('pe-shell pointer-events-none h-full w-full select-none', className)}
+        className={cn(
+            'pe-shell relative h-full w-full cursor-wait select-none overflow-hidden bg-decorative/15 backdrop-blur-[2px]',
+            className,
+        )}
     >
-        <Skeleton className='h-full w-full rounded-none bg-decorative/50' />
+        <div className='absolute inset-0 animate-[pe-shimmer_1.5s_ease-in-out_infinite] bg-gradient-to-r from-transparent via-white/60 to-transparent' />
     </div>
 );
 

--- a/src/main/resources/assets/js/page-editor/editor/components/placeholders/LoadingOverlayPlaceholder.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/components/placeholders/LoadingOverlayPlaceholder.tsx
@@ -1,0 +1,21 @@
+import {cn, Skeleton} from '@enonic/ui';
+
+import type {JSX} from 'preact';
+
+export type LoadingOverlayPlaceholderProps = {
+    className?: string;
+};
+
+const LOADING_OVERLAY_PLACEHOLDER_NAME = 'LoadingOverlayPlaceholder';
+
+export const LoadingOverlayPlaceholder = ({className}: LoadingOverlayPlaceholderProps): JSX.Element => (
+    <div
+        data-component={LOADING_OVERLAY_PLACEHOLDER_NAME}
+        data-loading=''
+        className={cn('pe-shell pointer-events-none h-full w-full select-none', className)}
+    >
+        <Skeleton className='h-full w-full rounded-none bg-decorative/50' />
+    </div>
+);
+
+LoadingOverlayPlaceholder.displayName = LOADING_OVERLAY_PLACEHOLDER_NAME;

--- a/src/main/resources/assets/js/page-editor/editor/rendering/editor-ui.css
+++ b/src/main/resources/assets/js/page-editor/editor/rendering/editor-ui.css
@@ -18,21 +18,27 @@
     }
 
     /*
-     * ! Tailwind 4 box-shadow token reset
-     * Tailwind 4 ships `@property` rules that register the five `--tw-*-shadow`
-     * tokens with `inherits: false`, so under spec compliance an element's
-     * `shadow-*`/`ring-*` value cannot leak into its descendants. Inside a
-     * shadow root the registration is not always effective — the tokens fall
-     * back to ordinary custom-property semantics (inheriting), and a parent's
-     * `shadow-lg` (e.g. `ContextMenu.Content`) cascades into every descendant.
-     * Children that later compose `box-shadow` from those vars then paint the
-     * inherited soft shadow even when they own no `shadow-*` utility.
+     * ! Tailwind 4 @property token reset
+     * Tailwind 4 ships `@property` rules for its internal `--tw-*` tokens with
+     * `inherits: false` and (for some) an `initial-value`. Inside a shadow root
+     * the registration is not always effective: tokens fall back to ordinary
+     * custom-property semantics, meaning they (a) inherit from ancestors and
+     * (b) have no initial value, so any `var(--tw-…)` reference resolves to
+     * IACVT and the entire declaration is dropped.
+     *
+     * Two symptoms in this codebase:
+     *   - `shadow-*` / `ring-*` from a parent (e.g. `ContextMenu.Content`)
+     *     cascades into descendants that own no `shadow-*` utility.
+     *   - `bg-gradient-to-* from-* via-* to-*` produces no background because
+     *     `--tw-gradient-*-position` defaults (`0%`/`50%`/`100%`) are missing,
+     *     making `--tw-gradient-via-stops` invalid (DevTools: "not defined").
      *
      * Resetting per element with `:where(*)` keeps specificity at zero — any
-     * `shadow-*` / `ring-*` utility still wins on the element that declares
-     * it — while severing the inheritance path so descendants always start at
-     * `0 0 #0000`. This emulates the `inherits: false` semantics that
-     * `@property` is supposed to provide.
+     * `shadow-*`/`ring-*`/`from-*`/`via-*`/`to-*` utility still wins on the
+     * element that declares it — while restoring the `inherits: false` +
+     * `initial-value` semantics that `@property` is supposed to provide. The
+     * gradient defaults mirror the @supports fallback Tailwind ships for
+     * older engines (https://github.com/tailwindlabs/tailwindcss `@layer properties`).
      */
     :where(*) {
         --tw-shadow: 0 0 #0000;
@@ -40,6 +46,16 @@
         --tw-ring-shadow: 0 0 #0000;
         --tw-inset-ring-shadow: 0 0 #0000;
         --tw-ring-offset-shadow: 0 0 #0000;
+
+        --tw-gradient-position: initial;
+        --tw-gradient-from: #0000;
+        --tw-gradient-via: #0000;
+        --tw-gradient-to: #0000;
+        --tw-gradient-stops: initial;
+        --tw-gradient-via-stops: initial;
+        --tw-gradient-from-position: 0%;
+        --tw-gradient-via-position: 50%;
+        --tw-gradient-to-position: 100%;
     }
 
     /*

--- a/src/main/resources/assets/js/page-editor/editor/rendering/pe-components.css
+++ b/src/main/resources/assets/js/page-editor/editor/rendering/pe-components.css
@@ -56,4 +56,13 @@
   .pe-parent-pulse {
     animation: pe-parent-pulse 750ms ease-out 1;
   }
+
+  @keyframes pe-shimmer {
+    0% {
+      transform: translateX(-100%);
+    }
+    100% {
+      transform: translateX(100%);
+    }
+  }
 }

--- a/src/main/resources/assets/js/page-editor/editor/rendering/placeholder-island.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/rendering/placeholder-island.tsx
@@ -4,12 +4,39 @@ import {injectEditorStyles} from './inject-styles';
 import {registerThemeHost, unregisterThemeHost} from './theme-sync';
 import type {PlaceholderIsland} from '../types';
 
-export function createPlaceholderIsland(container: HTMLElement, content: ComponentChildren): PlaceholderIsland {
+export interface CreatePlaceholderIslandOptions {
+    overlay?: boolean;
+}
+
+export function createPlaceholderIsland(
+    container: HTMLElement,
+    content: ComponentChildren,
+    options: CreatePlaceholderIslandOptions = {},
+): PlaceholderIsland {
     const host = document.createElement('div');
-    host.setAttribute(PLACEHOLDER_HOST_ATTR, 'true');
-    host.style.display = 'block';
-    host.style.width = '100%';
-    host.style.height = '100%';
+    host.setAttribute(PLACEHOLDER_HOST_ATTR, options.overlay ? 'overlay' : 'true');
+
+    let savedContainerPosition: string | undefined;
+
+    if (options.overlay) {
+        const computed = container.ownerDocument.defaultView?.getComputedStyle(container);
+        const currentPosition = computed?.position;
+        const needsContainingBlock = !currentPosition
+            || currentPosition === 'static'
+            || currentPosition === '';
+        if (needsContainingBlock) {
+            savedContainerPosition = container.style.position;
+            container.style.position = 'relative';
+        }
+        host.style.position = 'absolute';
+        host.style.inset = '0';
+        host.style.pointerEvents = 'none';
+    } else {
+        host.style.display = 'block';
+        host.style.width = '100%';
+        host.style.height = '100%';
+    }
+
     container.appendChild(host);
 
     const shadow = host.attachShadow({mode: 'open'});
@@ -29,6 +56,14 @@ export function createPlaceholderIsland(container: HTMLElement, content: Compone
             unregisterThemeHost(host);
             render(null, mount);
             host.remove();
+
+            if (savedContainerPosition !== undefined) {
+                if (savedContainerPosition === '') {
+                    container.style.removeProperty('position');
+                } else {
+                    container.style.position = savedContainerPosition;
+                }
+            }
         },
     };
 }

--- a/src/main/resources/assets/js/page-editor/editor/rendering/placeholder-island.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/rendering/placeholder-island.tsx
@@ -30,7 +30,6 @@ export function createPlaceholderIsland(
         }
         host.style.position = 'absolute';
         host.style.inset = '0';
-        host.style.pointerEvents = 'none';
     } else {
         host.style.display = 'block';
         host.style.width = '100%';


### PR DESCRIPTION
Skipped loading state in `shouldShowPlaceholder` for non-empty parts so the placeholder host is no longer appended next to existing rendered content during reload. Empty parts still get a loading placeholder (kind selector handles that branch). Added two regression tests in `reconcile.test.tsx`.

Closes #65

<sub>*Drafted with AI assistance*</sub>
