### PR TITLE
Page does not scroll when dragging a component near viewport edges #68

### DIFF
--- a/.storybook/page-editor/drag-autoscroll.stories.tsx
+++ b/.storybook/page-editor/drag-autoscroll.stories.tsx
@@ -1,0 +1,225 @@
+import type {Meta, StoryObj} from '@storybook/preact-vite';
+import {useEffect, useRef, useState} from 'preact/hooks';
+import {
+    calcEdgeIntensity,
+    createEdgeAutoScroll,
+    HOT_ZONE_PX,
+} from '../../src/main/resources/assets/js/page-editor/editor/interaction/drag/edge-auto-scroll';
+
+//
+// * Helpers
+//
+
+interface EdgeIntensities {
+    top: number;
+    bottom: number;
+    left: number;
+    right: number;
+}
+
+function calcIntensities(pointerX: number, pointerY: number, width: number, height: number): EdgeIntensities {
+    return {
+        top: calcEdgeIntensity(pointerY),
+        bottom: calcEdgeIntensity(height - pointerY),
+        left: calcEdgeIntensity(pointerX),
+        right: calcEdgeIntensity(width - pointerX),
+    };
+}
+
+function formatPercent(value: number): string {
+    return `${Math.round(value * 100)}%`;
+}
+
+//
+// * Meta
+//
+
+const meta = {
+    title: 'Page Editor/Drag Auto-Scroll',
+    parameters: {
+        layout: 'centered',
+    },
+    tags: ['autodocs'],
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+//
+// * Demo Component
+//
+
+interface AutoScrollDemoProps {
+    width?: number;
+    height?: number;
+    contentWidth?: number;
+    contentHeight?: number;
+}
+
+function AutoScrollDemo({
+    width = 480,
+    height = 360,
+    contentWidth = 480,
+    contentHeight = 2400,
+}: AutoScrollDemoProps) {
+    const wrapperRef = useRef<HTMLDivElement | null>(null);
+    const scrollerRef = useRef<HTMLDivElement | null>(null);
+    const [dragging, setDragging] = useState(false);
+    const [pointer, setPointer] = useState<{x: number; y: number} | undefined>(undefined);
+    const [scroll, setScroll] = useState({top: 0, left: 0});
+
+    useEffect(() => {
+        if (!dragging || !scrollerRef.current) return undefined;
+
+        const scroller = scrollerRef.current;
+        const edgeScroll = createEdgeAutoScroll({
+            getScroller: () => scroller,
+            onScrolled: () => setScroll({top: scroller.scrollTop, left: scroller.scrollLeft}),
+        });
+
+        const handleMouseMove = (event: MouseEvent): void => {
+            const rect = wrapperRef.current?.getBoundingClientRect();
+            if (rect) {
+                setPointer({x: event.clientX - rect.left, y: event.clientY - rect.top});
+            }
+            edgeScroll.update(event.clientX, event.clientY);
+        };
+
+        const handleMouseUp = (): void => {
+            edgeScroll.stop();
+            setDragging(false);
+            setPointer(undefined);
+        };
+
+        document.addEventListener('mousemove', handleMouseMove);
+        document.addEventListener('mouseup', handleMouseUp);
+        return () => {
+            edgeScroll.stop();
+            document.removeEventListener('mousemove', handleMouseMove);
+            document.removeEventListener('mouseup', handleMouseUp);
+        };
+    }, [dragging]);
+
+    const handleDragStart = (event: MouseEvent): void => {
+        event.preventDefault();
+        setDragging(true);
+        const rect = wrapperRef.current?.getBoundingClientRect();
+        if (rect) {
+            setPointer({x: event.clientX - rect.left, y: event.clientY - rect.top});
+        }
+    };
+
+    const horizontal = contentWidth > width;
+    const intensities = pointer ? calcIntensities(pointer.x, pointer.y, width, height) : undefined;
+
+    return (
+        <div className='flex flex-col gap-y-4 p-6'>
+            <div className='max-w-200 text-sm text-subtle'>
+                Press and hold <span className='font-medium'>Drag me</span>, then move the pointer
+                toward any edge of the scroll container. Auto-scroll uses a cubic ease-in curve.
+                Hot-zone shading and the intensity readout reflect the current curve value
+                (the actual velocity is <code>MIN + (MAX - MIN) * intensity</code>).
+                {horizontal && ' This demo also scrolls horizontally.'} Release to stop.
+            </div>
+
+            <div className='flex items-start gap-4'>
+                <button
+                    type='button'
+                    onMouseDown={handleDragStart}
+                    className='px-3 py-2 rounded-sm bg-blue-600 text-white cursor-grab select-none shadow-xs whitespace-nowrap'
+                >
+                    Drag me
+                </button>
+
+                <div ref={wrapperRef} className='relative shrink-0' style={{width, height}}>
+                    <div
+                        ref={scrollerRef}
+                        className='absolute inset-0 overflow-auto border border-default rounded-md bg-surface-subtle'
+                    >
+                        <div
+                            className='relative'
+                            style={{width: contentWidth, height: contentHeight}}
+                        >
+                            {Array.from({length: Math.ceil(contentHeight / 100)}, (_, idx) => (
+                                <div
+                                    key={idx}
+                                    className='m-2 h-20 rounded-sm bg-white shadow-xs flex items-center justify-center text-sm text-subtle'
+                                    style={{width: contentWidth - 16}}
+                                >
+                                    Block {idx + 1}
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+
+                    {dragging && (
+                        <>
+                            <div
+                                className='pointer-events-none absolute left-0 right-0 top-0 border-2 border-dashed border-rose-400/70 bg-rose-500'
+                                style={{height: HOT_ZONE_PX, opacity: 0.1 + (intensities?.top ?? 0) * 0.45}}
+                            />
+                            <div
+                                className='pointer-events-none absolute left-0 right-0 bottom-0 border-2 border-dashed border-rose-400/70 bg-rose-500'
+                                style={{height: HOT_ZONE_PX, opacity: 0.1 + (intensities?.bottom ?? 0) * 0.45}}
+                            />
+                            {horizontal && (
+                                <>
+                                    <div
+                                        className='pointer-events-none absolute top-0 bottom-0 left-0 border-2 border-dashed border-rose-400/70 bg-rose-500'
+                                        style={{width: HOT_ZONE_PX, opacity: 0.1 + (intensities?.left ?? 0) * 0.45}}
+                                    />
+                                    <div
+                                        className='pointer-events-none absolute top-0 bottom-0 right-0 border-2 border-dashed border-rose-400/70 bg-rose-500'
+                                        style={{width: HOT_ZONE_PX, opacity: 0.1 + (intensities?.right ?? 0) * 0.45}}
+                                    />
+                                </>
+                            )}
+                        </>
+                    )}
+
+                    {pointer && (
+                        <div
+                            className='pointer-events-none absolute z-10 size-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-blue-600 border-2 border-white shadow'
+                            style={{left: pointer.x, top: pointer.y}}
+                        />
+                    )}
+                </div>
+
+                <div className='font-mono text-xs text-subtle leading-relaxed min-w-32'>
+                    <div className='text-default font-medium mb-1'>scroll</div>
+                    <div>top: {Math.round(scroll.top)}px</div>
+                    <div>left: {Math.round(scroll.left)}px</div>
+                    {intensities && (
+                        <>
+                            <div className='text-default font-medium mt-3 mb-1'>intensity</div>
+                            <div className={intensities.top > 0 ? 'text-rose-600' : ''}>top: {formatPercent(intensities.top)}</div>
+                            <div className={intensities.bottom > 0 ? 'text-rose-600' : ''}>bot: {formatPercent(intensities.bottom)}</div>
+                            {horizontal && (
+                                <>
+                                    <div className={intensities.left > 0 ? 'text-rose-600' : ''}>left: {formatPercent(intensities.left)}</div>
+                                    <div className={intensities.right > 0 ? 'text-rose-600' : ''}>right: {formatPercent(intensities.right)}</div>
+                                </>
+                            )}
+                        </>
+                    )}
+                </div>
+            </div>
+
+        </div>
+    );
+}
+
+//
+// * Examples
+//
+
+export const Vertical: Story = {
+    name: 'Examples / Vertical Scroll',
+    render: () => <AutoScrollDemo />,
+};
+
+export const TwoAxis: Story = {
+    name: 'Examples / Two-Axis Scroll',
+    render: () => <AutoScrollDemo width={480} height={360} contentWidth={1400} contentHeight={2000} />,
+};

--- a/src/main/resources/assets/js/page-editor/editor/interaction/drag/component-drag.test.ts
+++ b/src/main/resources/assets/js/page-editor/editor/interaction/drag/component-drag.test.ts
@@ -768,4 +768,72 @@ describe('initComponentDrag', () => {
         window.dispatchEvent(new Event('blur'));
         stop();
     });
+
+    it('auto-scrolls the page when a dragged component nears the viewport bottom edge', async () => {
+        Object.defineProperty(window, 'innerHeight', {configurable: true, value: 400});
+
+        const scrollingElement = document.scrollingElement ?? document.documentElement;
+        Object.defineProperty(scrollingElement, 'scrollHeight', {configurable: true, value: 2000});
+        Object.defineProperty(scrollingElement, 'clientHeight', {configurable: true, value: 400});
+        let scrollTop = 0;
+        const observedDeltas: number[] = [];
+        Object.defineProperty(scrollingElement, 'scrollTop', {
+            configurable: true,
+            get: () => scrollTop,
+            set: (value: number) => {
+                const next = Math.max(0, Math.min(1600, value));
+                observedDeltas.push(next - scrollTop);
+                scrollTop = next;
+            },
+        });
+
+        const region = document.createElement('section');
+        region.dataset.portalRegion = 'main';
+        const item = document.createElement('article');
+        item.dataset.portalComponentType = 'part';
+        region.append(item);
+        document.body.appendChild(region);
+
+        setRect(item, {top: 20, left: 0, width: 300, height: 80});
+
+        const records: Record<string, ComponentRecord> = {
+            '/main': createRecord('/main', region, 'region', ComponentPath.root().toString(), ['/main/0']),
+            '/main/0': createRecord('/main/0', item, 'part', '/main'),
+        };
+
+        setRegistry(records);
+        rebuildIndex(records);
+        vi.mocked(document.elementsFromPoint).mockReturnValue([]);
+
+        const frames: Array<(now: number) => void> = [];
+        const originalRAF = window.requestAnimationFrame;
+        const originalCAF = window.cancelAnimationFrame;
+        window.requestAnimationFrame = ((cb: (now: number) => void): number => {
+            frames.push(cb);
+            return frames.length;
+        }) as typeof requestAnimationFrame;
+        window.cancelAnimationFrame = ((id: number): void => {
+            frames[id - 1] = () => {};
+        }) as typeof cancelAnimationFrame;
+
+        const stop = initComponentDrag();
+
+        dispatchMouseDown(item, 50, 50);
+        dispatchMouseMove(50, 70);
+
+        // Drag is active — now move pointer near the bottom of the viewport
+        dispatchMouseMove(50, 395);
+
+        // Drive two frames: first primes the timestamp, second performs the scroll
+        frames.shift()?.(1000);
+        frames.shift()?.(1016);
+
+        expect(observedDeltas.length).toBeGreaterThan(0);
+        expect(observedDeltas[0]).toBeGreaterThan(0);
+
+        window.requestAnimationFrame = originalRAF;
+        window.cancelAnimationFrame = originalCAF;
+        window.dispatchEvent(new Event('blur'));
+        stop();
+    });
 });

--- a/src/main/resources/assets/js/page-editor/editor/interaction/drag/component-drag.ts
+++ b/src/main/resources/assets/js/page-editor/editor/interaction/drag/component-drag.ts
@@ -32,6 +32,7 @@ import {
     getElementsAtPoint,
     resolveInsertionIndex,
 } from './drop-positioning';
+import {createEdgeAutoScroll} from './edge-auto-scroll';
 
 const DRAG_START_DISTANCE = 8;
 
@@ -115,8 +116,11 @@ function fireDragCanceled(path: string): void {
 }
 
 let activeDragSession: ActiveComponentDrag | undefined;
+let stopEdgeScroll: (() => void) | undefined;
 
 function destroyActiveDrag(canceled: boolean): void {
+    stopEdgeScroll?.();
+
     if (!activeDragSession) {
         setDragState(undefined);
         return;
@@ -144,6 +148,15 @@ export function cancelActiveDrag(): void {
 
 export function initComponentDrag(): () => void {
     let pending: PendingComponentDrag | undefined;
+
+    const recomputeDropTarget = (): void => {
+        if (!activeDragSession) return;
+        resolveDropTarget(activeDragSession);
+        publishState(activeDragSession);
+    };
+
+    const edgeScroll = createEdgeAutoScroll({onScrolled: recomputeDropTarget});
+    stopEdgeScroll = edgeScroll.stop;
 
     const beginDrag = (path: string, x: number, y: number): void => {
         const record = getRecord(path);
@@ -206,6 +219,7 @@ export function initComponentDrag(): () => void {
         if (activeDragSession) {
             activeDragSession.x = event.clientX;
             activeDragSession.y = event.clientY;
+            edgeScroll.update(event.clientX, event.clientY);
             resolveDropTarget(activeDragSession);
             publishState(activeDragSession);
             return;
@@ -252,17 +266,35 @@ export function initComponentDrag(): () => void {
         cancelActiveDrag();
     };
 
+    // ? Best-effort stop signal — `mouseleave` is unreliable across browsers
+    // when the pointer crosses an iframe boundary, so we treat it as a hint, not a guarantee.
+    const handleDocumentMouseLeave = () => {
+        edgeScroll.stop();
+    };
+
+    const handleVisibilityChange = () => {
+        if (document.hidden) {
+            edgeScroll.stop();
+        }
+    };
+
     document.addEventListener('mousedown', handleMouseDown, {capture: true});
     document.addEventListener('mousemove', handleMouseMove, {capture: true, passive: true});
     document.addEventListener('mouseup', handleMouseUp, {capture: true});
+    document.addEventListener('mouseleave', handleDocumentMouseLeave);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
     window.addEventListener('blur', handleWindowBlur);
 
     return () => {
         pending = undefined;
         cancelActiveDrag();
+        edgeScroll.stop();
+        stopEdgeScroll = undefined;
         document.removeEventListener('mousedown', handleMouseDown, {capture: true});
         document.removeEventListener('mousemove', handleMouseMove, {capture: true});
         document.removeEventListener('mouseup', handleMouseUp, {capture: true});
+        document.removeEventListener('mouseleave', handleDocumentMouseLeave);
+        document.removeEventListener('visibilitychange', handleVisibilityChange);
         window.removeEventListener('blur', handleWindowBlur);
         setDragState(undefined);
     };

--- a/src/main/resources/assets/js/page-editor/editor/interaction/drag/context-window-drag.ts
+++ b/src/main/resources/assets/js/page-editor/editor/interaction/drag/context-window-drag.ts
@@ -25,6 +25,7 @@ import {
     getElementsAtPoint,
     resolveInsertionIndex,
 } from './drop-positioning';
+import {createEdgeAutoScroll} from './edge-auto-scroll';
 
 interface ContextWindowDragSession {
     itemType: ItemType;
@@ -110,6 +111,14 @@ function fireDragCanceled(): void {
 export function initContextWindowDrag(): () => void {
     let session: ContextWindowDragSession | undefined;
 
+    const recomputeDropTarget = (): void => {
+        if (!session?.visible || session.x == null || session.y == null) return;
+        resolveDropTarget(session, session.x, session.y);
+        publishState(session);
+    };
+
+    const edgeScroll = createEdgeAutoScroll({onScrolled: recomputeDropTarget});
+
     const resetVisibleState = () => {
         if (!session) {
             return;
@@ -120,6 +129,8 @@ export function initContextWindowDrag(): () => void {
     };
 
     const destroySession = (canceled: boolean) => {
+        edgeScroll.stop();
+
         if (!session) {
             return;
         }
@@ -181,6 +192,7 @@ export function initContextWindowDrag(): () => void {
         closeContextMenu();
 
         if (!session.visible) {
+            edgeScroll.stop();
             resetVisibleState();
             return;
         }
@@ -195,6 +207,7 @@ export function initContextWindowDrag(): () => void {
 
         session.x = event.clientX;
         session.y = event.clientY;
+        edgeScroll.update(event.clientX, event.clientY);
         resolveDropTarget(session, event.clientX, event.clientY);
         publishState(session);
     };
@@ -218,16 +231,31 @@ export function initContextWindowDrag(): () => void {
         destroySession(true);
     };
 
+    const handleDocumentMouseLeave = () => {
+        edgeScroll.stop();
+    };
+
+    const handleVisibilityChange = () => {
+        if (document.hidden) {
+            edgeScroll.stop();
+        }
+    };
+
     CreateOrDestroyDraggableEvent.on(handleCreateOrDestroy);
     SetDraggableVisibleEvent.on(handleVisible);
     document.addEventListener('mousemove', handleMouseMove, {capture: true, passive: true});
     document.addEventListener('mouseup', handleMouseUp, {capture: true});
+    document.addEventListener('mouseleave', handleDocumentMouseLeave);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
 
     return () => {
         CreateOrDestroyDraggableEvent.un(handleCreateOrDestroy);
         SetDraggableVisibleEvent.un(handleVisible);
         document.removeEventListener('mousemove', handleMouseMove, {capture: true});
         document.removeEventListener('mouseup', handleMouseUp, {capture: true});
+        document.removeEventListener('mouseleave', handleDocumentMouseLeave);
+        document.removeEventListener('visibilitychange', handleVisibilityChange);
+        edgeScroll.stop();
         if (session) {
             clearTarget(session);
             session = undefined;

--- a/src/main/resources/assets/js/page-editor/editor/interaction/drag/edge-auto-scroll.test.ts
+++ b/src/main/resources/assets/js/page-editor/editor/interaction/drag/edge-auto-scroll.test.ts
@@ -1,0 +1,386 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {createEdgeAutoScroll} from './edge-auto-scroll';
+
+//
+// * Test Harness
+//
+
+type Frame = (now: number) => void;
+
+interface FakeScroller {
+    element: Element;
+    deltas: Array<{top: number; left: number}>;
+    setScrollTop(value: number): void;
+    setScrollLeft(value: number): void;
+    getScrollTop(): number;
+    getScrollLeft(): number;
+}
+
+interface FakeScrollerOptions {
+    scrollHeight?: number;
+    scrollWidth?: number;
+    clientHeight?: number;
+    clientWidth?: number;
+    scrollTop?: number;
+    scrollLeft?: number;
+}
+
+function createFakeScroller(opts: FakeScrollerOptions = {}): FakeScroller {
+    const state = {
+        scrollHeight: opts.scrollHeight ?? 2000,
+        scrollWidth: opts.scrollWidth ?? 600,
+        clientHeight: opts.clientHeight ?? 400,
+        clientWidth: opts.clientWidth ?? 600,
+        scrollTop: opts.scrollTop ?? 0,
+        scrollLeft: opts.scrollLeft ?? 0,
+    };
+
+    const clampTop = (value: number): number =>
+        Math.max(0, Math.min(state.scrollHeight - state.clientHeight, value));
+    const clampLeft = (value: number): number =>
+        Math.max(0, Math.min(state.scrollWidth - state.clientWidth, value));
+
+    const scrollDeltas: Array<{top: number; left: number}> = [];
+
+    const element = {
+        get scrollTop() {
+            return state.scrollTop;
+        },
+        set scrollTop(value: number) {
+            const next = clampTop(value);
+            scrollDeltas.push({top: next - state.scrollTop, left: 0});
+            state.scrollTop = next;
+        },
+        get scrollLeft() {
+            return state.scrollLeft;
+        },
+        set scrollLeft(value: number) {
+            const next = clampLeft(value);
+            const last = scrollDeltas[scrollDeltas.length - 1];
+            if (last && last.left === 0) {
+                last.left = next - state.scrollLeft;
+            } else {
+                scrollDeltas.push({top: 0, left: next - state.scrollLeft});
+            }
+            state.scrollLeft = next;
+        },
+        get scrollHeight() {
+            return state.scrollHeight;
+        },
+        get scrollWidth() {
+            return state.scrollWidth;
+        },
+        get clientHeight() {
+            return state.clientHeight;
+        },
+        get clientWidth() {
+            return state.clientWidth;
+        },
+        getBoundingClientRect() {
+            return {
+                top: 0,
+                left: 0,
+                right: state.clientWidth,
+                bottom: state.clientHeight,
+                width: state.clientWidth,
+                height: state.clientHeight,
+            } as DOMRect;
+        },
+    } as unknown as Element;
+
+    return {
+        element,
+        deltas: scrollDeltas,
+        setScrollTop(value: number) {
+            state.scrollTop = value;
+        },
+        setScrollLeft(value: number) {
+            state.scrollLeft = value;
+        },
+        getScrollTop() {
+            return state.scrollTop;
+        },
+        getScrollLeft() {
+            return state.scrollLeft;
+        },
+    };
+}
+
+let frameQueue: Array<{id: number; cb: Frame}>;
+let nextFrameId: number;
+let originalRAF: typeof requestAnimationFrame;
+let originalCAF: typeof cancelAnimationFrame;
+let originalInnerHeight: number;
+
+function flushFrame(now: number): void {
+    const next = frameQueue.shift();
+    if (!next) return;
+    next.cb(now);
+}
+
+beforeEach(() => {
+    frameQueue = [];
+    nextFrameId = 1;
+    originalRAF = window.requestAnimationFrame;
+    originalCAF = window.cancelAnimationFrame;
+    originalInnerHeight = window.innerHeight;
+
+    window.requestAnimationFrame = ((cb: Frame): number => {
+        const id = nextFrameId++;
+        frameQueue.push({id, cb});
+        return id;
+    }) as typeof requestAnimationFrame;
+
+    window.cancelAnimationFrame = ((id: number): void => {
+        frameQueue = frameQueue.filter((entry) => entry.id !== id);
+    }) as typeof cancelAnimationFrame;
+
+    Object.defineProperty(window, 'innerHeight', {configurable: true, value: 400});
+});
+
+afterEach(() => {
+    window.requestAnimationFrame = originalRAF;
+    window.cancelAnimationFrame = originalCAF;
+    Object.defineProperty(window, 'innerHeight', {configurable: true, value: originalInnerHeight});
+});
+
+//
+// * Tests
+//
+
+describe('createEdgeAutoScroll', () => {
+    it('does not scroll when pointer is in the middle of the viewport', () => {
+        const scroller = createFakeScroller();
+        const onScrolled = vi.fn();
+        const ctrl = createEdgeAutoScroll({onScrolled, getScroller: () => scroller.element});
+
+        ctrl.update(200, 200);
+
+        expect(frameQueue).toHaveLength(0);
+        expect(scroller.deltas).toHaveLength(0);
+        expect(onScrolled).not.toHaveBeenCalled();
+    });
+
+    it('scrolls down when pointer is near the bottom edge', () => {
+        const scroller = createFakeScroller();
+        const onScrolled = vi.fn();
+        const ctrl = createEdgeAutoScroll({onScrolled, getScroller: () => scroller.element});
+
+        ctrl.update(200, 390); // 10px from bottom of 400px viewport
+
+        // First tick primes the timestamp
+        flushFrame(1000);
+        expect(scroller.deltas).toHaveLength(0);
+
+        // Second tick performs the scroll
+        flushFrame(1016);
+        expect(scroller.deltas).toHaveLength(1);
+        expect(scroller.deltas[0].top).toBeGreaterThan(0);
+        expect(onScrolled).toHaveBeenCalledTimes(1);
+    });
+
+    it('scrolls up with negative delta when pointer is near the top edge', () => {
+        const scroller = createFakeScroller({scrollTop: 500});
+        const onScrolled = vi.fn();
+        const ctrl = createEdgeAutoScroll({onScrolled, getScroller: () => scroller.element});
+
+        ctrl.update(200, 10); // 10px from top
+
+        flushFrame(1000);
+        flushFrame(1016);
+
+        expect(scroller.deltas).toHaveLength(1);
+        expect(scroller.deltas[0].top).toBeLessThan(0);
+    });
+
+    it('uses a larger velocity when pointer is deeper into the hot zone', () => {
+        const scroller = createFakeScroller();
+        const onScrolled = vi.fn();
+        const ctrl = createEdgeAutoScroll({onScrolled, getScroller: () => scroller.element});
+
+        ctrl.update(200, 345); // 55px from bottom — shallow inside 64px hot zone
+        flushFrame(1000);
+        flushFrame(1016);
+        const shallowDy = scroller.deltas[0].top;
+
+        ctrl.stop();
+        scroller.setScrollTop(0);
+        scroller.deltas.length = 0;
+
+        const ctrl2 = createEdgeAutoScroll({onScrolled, getScroller: () => scroller.element});
+        ctrl2.update(200, 398); // 2px from bottom — deep in zone
+        flushFrame(2000);
+        flushFrame(2016);
+        const deepDy = scroller.deltas[0].top;
+
+        expect(deepDy).toBeGreaterThan(shallowDy);
+    });
+
+    it('stops the loop when the scroller hits its bottom boundary', () => {
+        const scroller = createFakeScroller({scrollTop: 1600, scrollHeight: 2000, clientHeight: 400});
+        const onScrolled = vi.fn();
+        const ctrl = createEdgeAutoScroll({onScrolled, getScroller: () => scroller.element});
+
+        ctrl.update(200, 395);
+        flushFrame(1000);
+        flushFrame(1016);
+
+        expect(frameQueue).toHaveLength(0);
+        expect(onScrolled).not.toHaveBeenCalled();
+    });
+
+    it('zeroes velocity and cancels rAF when the pointer leaves the hot zone', () => {
+        const scroller = createFakeScroller();
+        const ctrl = createEdgeAutoScroll({onScrolled: vi.fn(), getScroller: () => scroller.element});
+
+        ctrl.update(200, 395);
+        expect(frameQueue).toHaveLength(1);
+
+        ctrl.update(200, 200);
+        expect(frameQueue).toHaveLength(0);
+    });
+
+    it('stop() is idempotent and prevents further frames', () => {
+        const scroller = createFakeScroller();
+        const onScrolled = vi.fn();
+        const ctrl = createEdgeAutoScroll({onScrolled, getScroller: () => scroller.element});
+
+        ctrl.update(200, 395);
+        ctrl.stop();
+        ctrl.stop();
+
+        expect(frameQueue).toHaveLength(0);
+
+        // Even if a frame somehow leaks through, onScrolled must not fire
+        ctrl.stop();
+        expect(onScrolled).not.toHaveBeenCalled();
+    });
+
+    it('clamps a large frame delta so a throttled tab does not snap the page', () => {
+        const scroller = createFakeScroller();
+        const onScrolled = vi.fn();
+        const ctrl = createEdgeAutoScroll({onScrolled, getScroller: () => scroller.element});
+
+        ctrl.update(200, 395);
+        flushFrame(1000);
+        flushFrame(5000); // 4-second gap, should clamp to 32ms
+
+        // With MAX 1.1 px/ms clamped at 32ms, dy is at most ~35
+        expect(scroller.deltas[0].top).toBeLessThanOrEqual(32 * 1.1);
+    });
+
+    it('scrolls right when pointer is near the right edge', () => {
+        const scroller = createFakeScroller({clientWidth: 600, scrollWidth: 2000});
+        const onScrolled = vi.fn();
+        const ctrl = createEdgeAutoScroll({onScrolled, getScroller: () => scroller.element});
+
+        ctrl.update(595, 200); // 5px from right of 600px viewport
+
+        flushFrame(1000);
+        flushFrame(1016);
+
+        expect(scroller.deltas[0].left).toBeGreaterThan(0);
+        expect(scroller.deltas[0].top).toBe(0);
+    });
+
+    it('scrolls left when pointer is near the left edge', () => {
+        const scroller = createFakeScroller({clientWidth: 600, scrollWidth: 2000, scrollLeft: 500});
+        const onScrolled = vi.fn();
+        const ctrl = createEdgeAutoScroll({onScrolled, getScroller: () => scroller.element});
+
+        ctrl.update(5, 200);
+
+        flushFrame(1000);
+        flushFrame(1016);
+
+        expect(scroller.deltas[0].left).toBeLessThan(0);
+    });
+
+    it('scrolls diagonally when pointer is near a corner', () => {
+        const scroller = createFakeScroller({clientWidth: 600, scrollWidth: 2000});
+        const onScrolled = vi.fn();
+        const ctrl = createEdgeAutoScroll({onScrolled, getScroller: () => scroller.element});
+
+        // Pointer near bottom-right corner
+        ctrl.update(590, 395);
+
+        flushFrame(1000);
+        flushFrame(1016);
+
+        expect(scroller.deltas[0].left).toBeGreaterThan(0);
+        expect(scroller.deltas[0].top).toBeGreaterThan(0);
+    });
+
+    it('only stops when blocked on every active axis', () => {
+        // Already at the right edge — horizontal blocked, but vertical scroll should still happen
+        const scroller = createFakeScroller({clientWidth: 600, scrollWidth: 600});
+        const onScrolled = vi.fn();
+        const ctrl = createEdgeAutoScroll({onScrolled, getScroller: () => scroller.element});
+
+        ctrl.update(595, 395); // near right and bottom
+
+        flushFrame(1000);
+        flushFrame(1016);
+
+        expect(scroller.deltas[0].top).toBeGreaterThan(0);
+        expect(scroller.deltas[0].left).toBe(0);
+        expect(onScrolled).toHaveBeenCalledTimes(1);
+    });
+
+    it('produces symmetric velocities at top and bottom edges when the scroller has a border', () => {
+        // Scroller has a 2px border on each side. Outer rect 400, inner clientHeight 396.
+        // If the controller mixed rect.top with clientHeight, the bottom edge would
+        // appear ~4px deeper than the top edge for the same visual distance.
+        const state = {clientHeight: 396, scrollHeight: 2000, scrollTop: 500, clientWidth: 600, scrollWidth: 600, scrollLeft: 0};
+        const observed: Array<{top: number; left: number}> = [];
+        const element = {
+            get scrollTop() { return state.scrollTop; },
+            set scrollTop(value: number) {
+                observed.push({top: value - state.scrollTop, left: 0});
+                state.scrollTop = value;
+            },
+            get scrollLeft() { return state.scrollLeft; },
+            set scrollLeft(value: number) { state.scrollLeft = value; },
+            get scrollHeight() { return state.scrollHeight; },
+            get scrollWidth() { return state.scrollWidth; },
+            get clientHeight() { return state.clientHeight; },
+            get clientWidth() { return state.clientWidth; },
+            getBoundingClientRect: () => ({top: 0, left: 0, right: 600, bottom: 400, width: 600, height: 400}) as DOMRect,
+        } as unknown as Element;
+
+        const onScrolled = vi.fn();
+        const ctrl = createEdgeAutoScroll({onScrolled, getScroller: () => element});
+
+        // 10px from outer top
+        ctrl.update(300, 10);
+        flushFrame(1000);
+        flushFrame(1016);
+        const topDy = Math.abs(observed[0].top);
+
+        observed.length = 0;
+        ctrl.stop();
+
+        // 10px from outer bottom (rect.height = 400 → y = 390)
+        ctrl.update(300, 390);
+        flushFrame(2000);
+        flushFrame(2016);
+        const bottomDy = Math.abs(observed[0].top);
+
+        // Tolerate microscopic float diff from the dt calculation
+        expect(Math.abs(topDy - bottomDy)).toBeLessThan(0.1);
+    });
+
+    it('reschedules a frame after each successful scroll', () => {
+        const scroller = createFakeScroller();
+        const onScrolled = vi.fn();
+        const ctrl = createEdgeAutoScroll({onScrolled, getScroller: () => scroller.element});
+
+        ctrl.update(200, 395);
+        flushFrame(1000);
+        flushFrame(1016);
+        expect(frameQueue).toHaveLength(1);
+
+        flushFrame(1032);
+        expect(onScrolled).toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/main/resources/assets/js/page-editor/editor/interaction/drag/edge-auto-scroll.ts
+++ b/src/main/resources/assets/js/page-editor/editor/interaction/drag/edge-auto-scroll.ts
@@ -1,0 +1,182 @@
+/**
+ * Auto-scrolls a viewport while a drag operation is active and the pointer
+ * approaches any of its edges. Drives scrolling from `requestAnimationFrame`
+ * with time-based velocity (px/ms) so behavior is identical across refresh rates.
+ *
+ * The controller is stateful but isolated; create one per drag-session lifecycle.
+ */
+
+export const HOT_ZONE_PX = 64;
+const MAX_SPEED_PX_PER_MS = 1.1;
+const MIN_SPEED_PX_PER_MS = 0.08;
+const MAX_DT_MS = 32;
+
+export type EdgeAutoScrollOptions = {
+    onScrolled: () => void;
+    getScroller?: () => Element | undefined;
+};
+
+export type EdgeAutoScroll = {
+    update(x: number, y: number): void;
+    stop(): void;
+};
+
+function defaultScroller(): Element | undefined {
+    return document.scrollingElement ?? document.documentElement ?? undefined;
+}
+
+function isDocumentScroller(scroller: Element): boolean {
+    return scroller === document.scrollingElement || scroller === document.documentElement;
+}
+
+function getViewportSize(scroller: Element): {width: number; height: number; top: number; left: number} {
+    if (isDocumentScroller(scroller)) {
+        return {width: window.innerWidth, height: window.innerHeight, top: 0, left: 0};
+    }
+
+    // ! Use outer rect dimensions, not clientWidth/Height, to keep distance-from-edge symmetric
+    const rect = scroller.getBoundingClientRect();
+    return {width: rect.width, height: rect.height, top: rect.top, left: rect.left};
+}
+
+/**
+ * Cubic ease-in normalized to 0..1, where 0 = outside the hot zone and 1 = at the viewport edge.
+ * Scroll velocity is `MIN_SPEED + (MAX_SPEED - MIN_SPEED) * intensity`.
+ */
+export function calcEdgeIntensity(distFromEdge: number): number {
+    if (distFromEdge >= HOT_ZONE_PX) return 0;
+    const t = 1 - Math.max(0, distFromEdge) / HOT_ZONE_PX;
+    return t * t * t;
+}
+
+function calcSpeedPxPerMs(distFromEdge: number): number {
+    const intensity = calcEdgeIntensity(distFromEdge);
+    if (intensity === 0) return 0;
+    return MIN_SPEED_PX_PER_MS + (MAX_SPEED_PX_PER_MS - MIN_SPEED_PX_PER_MS) * intensity;
+}
+
+function calcAxisVelocity(distFromStart: number, distFromEnd: number): number {
+    if (distFromStart < HOT_ZONE_PX && distFromStart < distFromEnd) {
+        return -calcSpeedPxPerMs(distFromStart);
+    }
+    if (distFromEnd < HOT_ZONE_PX) {
+        return calcSpeedPxPerMs(distFromEnd);
+    }
+    return 0;
+}
+
+export function createEdgeAutoScroll(options: EdgeAutoScrollOptions): EdgeAutoScroll {
+    const {onScrolled, getScroller = defaultScroller} = options;
+
+    let active = false;
+    let vxPxPerMs = 0;
+    let vyPxPerMs = 0;
+    let rafId: number | undefined;
+    let lastTimestamp: number | undefined;
+
+    const cancelFrame = (): void => {
+        if (rafId != null) {
+            cancelAnimationFrame(rafId);
+            rafId = undefined;
+        }
+        lastTimestamp = undefined;
+    };
+
+    const stop = (): void => {
+        active = false;
+        vxPxPerMs = 0;
+        vyPxPerMs = 0;
+        cancelFrame();
+    };
+
+    const tick = (now: number): void => {
+        rafId = undefined;
+        if (!active || (vxPxPerMs === 0 && vyPxPerMs === 0)) return;
+
+        const scroller = getScroller();
+        if (!scroller) {
+            stop();
+            return;
+        }
+
+        if (lastTimestamp == null) {
+            lastTimestamp = now;
+            rafId = requestAnimationFrame(tick);
+            return;
+        }
+
+        // Clamp dt so a backgrounded tab doesn't snap the page in one frame
+        const dt = Math.min(now - lastTimestamp, MAX_DT_MS);
+        lastTimestamp = now;
+
+        const requestedDx = vxPxPerMs * dt;
+        const requestedDy = vyPxPerMs * dt;
+
+        const atTop = scroller.scrollTop <= 0;
+        const atBottom = scroller.scrollTop + scroller.clientHeight >= scroller.scrollHeight;
+        const atLeft = scroller.scrollLeft <= 0;
+        const atRight = scroller.scrollLeft + scroller.clientWidth >= scroller.scrollWidth;
+
+        const dy = (requestedDy < 0 && atTop) || (requestedDy > 0 && atBottom) ? 0 : requestedDy;
+        const dx = (requestedDx < 0 && atLeft) || (requestedDx > 0 && atRight) ? 0 : requestedDx;
+
+        if (dx === 0 && dy === 0) {
+            stop();
+            return;
+        }
+
+        const beforeTop = scroller.scrollTop;
+        const beforeLeft = scroller.scrollLeft;
+        // ! Direct assignment bypasses CSS `scroll-behavior`; `scrollBy({behavior: 'instant'})` can queue
+        if (dy !== 0) scroller.scrollTop += dy;
+        if (dx !== 0) scroller.scrollLeft += dx;
+        const afterTop = scroller.scrollTop;
+        const afterLeft = scroller.scrollLeft;
+
+        if (beforeTop === afterTop && beforeLeft === afterLeft) {
+            stop();
+            return;
+        }
+
+        if (!active) return;
+
+        onScrolled();
+
+        if (!active || (vxPxPerMs === 0 && vyPxPerMs === 0)) return;
+        rafId = requestAnimationFrame(tick);
+    };
+
+    const update = (x: number, y: number): void => {
+        const scroller = getScroller();
+        if (!scroller) {
+            stop();
+            return;
+        }
+
+        const {width, height, top, left} = getViewportSize(scroller);
+        const localX = x - left;
+        const localY = y - top;
+
+        const nextVy = calcAxisVelocity(localY, height - localY);
+        const nextVx = calcAxisVelocity(localX, width - localX);
+
+        if (nextVx === 0 && nextVy === 0) {
+            vxPxPerMs = 0;
+            vyPxPerMs = 0;
+            cancelFrame();
+            active = false;
+            return;
+        }
+
+        vxPxPerMs = nextVx;
+        vyPxPerMs = nextVy;
+        active = true;
+
+        if (rafId == null) {
+            lastTimestamp = undefined;
+            rafId = requestAnimationFrame(tick);
+        }
+    };
+
+    return {update, stop};
+}


### PR DESCRIPTION
Added auto-scroll while a drag is active and the pointer approaches a viewport edge. `requestAnimationFrame`-driven with time-based velocity (px/ms) so behavior is identical across refresh rates. Cubic ease-in curve, 64px hot zone, both axes supported with per-axis boundary checks. Wired into `component-drag` and `context-window-drag`. Direct `scrollTop`/`scrollLeft` assignment bypasses CSS `scroll-behavior` to stay fully synchronous. Storybook story `Page Editor / Drag Auto-Scroll` for visual verification.

Closes #68

<sub>*Drafted with AI assistance*</sub>
