### PR TITLE
Give drag dropzone a subtle background and dashed border #71

### DIFF
--- a/.storybook/page-editor/placeholders.stories.tsx
+++ b/.storybook/page-editor/placeholders.stories.tsx
@@ -2,6 +2,7 @@ import type {Meta, StoryObj} from '@storybook/preact-vite';
 import type {ComponentChildren} from 'preact';
 import {useEffect, useRef} from 'preact/hooks';
 import {ComponentPlaceholder} from '../../src/main/resources/assets/js/page-editor/editor/components/placeholders/ComponentPlaceholder';
+import {DragPlaceholder} from '../../src/main/resources/assets/js/page-editor/editor/components/placeholders/DragPlaceholder';
 import {EmptyPlaceholder} from '../../src/main/resources/assets/js/page-editor/editor/components/placeholders/EmptyPlaceholder';
 import {LoadingOverlayPlaceholder} from '../../src/main/resources/assets/js/page-editor/editor/components/placeholders/LoadingOverlayPlaceholder';
 import {LoadingPlaceholder} from '../../src/main/resources/assets/js/page-editor/editor/components/placeholders/LoadingPlaceholder';
@@ -59,6 +60,15 @@ export const DropzoneDefault: Story = {
     render: () => (
         <IslandMount className='w-160'>
             <RegionPlaceholder path='/main' regionName='main' />
+        </IslandMount>
+    ),
+};
+
+export const DropzoneDragPlaceholder: Story = {
+    name: 'Dropzone / Drag Placeholder',
+    render: () => (
+        <IslandMount className='w-160'>
+            <DragPlaceholder />
         </IslandMount>
     ),
 };

--- a/src/main/resources/assets/js/page-editor/editor/components/placeholders/DragPlaceholder.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/components/placeholders/DragPlaceholder.tsx
@@ -9,7 +9,11 @@ export type DragPlaceholderProps = {
 const DRAG_PLACEHOLDER_NAME = 'DragPlaceholder';
 
 export const DragPlaceholder = ({className}: DragPlaceholderProps): JSX.Element => {
-    return <div data-component={DRAG_PLACEHOLDER_NAME} className={cn('min-h-30', className)} />;
+    return (
+        <div data-component={DRAG_PLACEHOLDER_NAME} className={cn('p-2.5', className)}>
+            <div className='pe-dash pe-dash-select min-h-25 bg-bdr-select/8' />
+        </div>
+    );
 };
 
 DragPlaceholder.displayName = DRAG_PLACEHOLDER_NAME;

--- a/src/main/resources/assets/js/page-editor/editor/rendering/pe-components.css
+++ b/src/main/resources/assets/js/page-editor/editor/rendering/pe-components.css
@@ -41,6 +41,10 @@
     --_dash: var(--color-error);
   }
 
+  .pe-dash-select {
+    --_dash: var(--color-bdr-select);
+  }
+
   @keyframes pe-parent-pulse {
     0% {
       box-shadow: inset 0 0 0 0 transparent;


### PR DESCRIPTION
## Changes

- Replaced the transparent `DragPlaceholder` with a `bg-bdr-select/8` tint and `.pe-dash` dashed border matching the selection overlay, kept text-free
- Restored a Storybook story to preview the drag placeholder

Closes #71

<sub>*Drafted with AI assistance*</sub>
