### PR TITLE
Drag placeholder renders far below empty region drop target #74

### DIFF
--- a/.storybook/page-editor/drag-empty-region.stories.tsx
+++ b/.storybook/page-editor/drag-empty-region.stories.tsx
@@ -1,0 +1,183 @@
+import type {Meta, StoryObj} from '@storybook/preact-vite';
+import {ComponentPath} from '@enonic/lib-contentstudio/app/page/region/ComponentPath';
+import {useEffect, useRef} from 'preact/hooks';
+import {DragPlaceholderPortal} from '../../src/main/resources/assets/js/page-editor/editor/components/overlay/DragPlaceholderPortal';
+import {
+    initPlaceholderDragSync,
+    syncPlaceholders,
+} from '../../src/main/resources/assets/js/page-editor/editor/adapter/placeholder-lifecycle';
+import {setCurrentPageView} from '../../src/main/resources/assets/js/page-editor/editor/bridge';
+import {
+    initGeometryTriggers,
+    markDirty,
+} from '../../src/main/resources/assets/js/page-editor/editor/geometry/scheduler';
+import {ensurePlaceholderAnchor} from '../../src/main/resources/assets/js/page-editor/editor/interaction/drag/drop-positioning';
+import {createOverlayHost} from '../../src/main/resources/assets/js/page-editor/editor/rendering/overlay-host';
+import {rebuildIndex} from '../../src/main/resources/assets/js/page-editor/editor/stores/element-index';
+import {
+    getRecord,
+    setDragState,
+    setModifyAllowed,
+    setRegistry,
+} from '../../src/main/resources/assets/js/page-editor/editor/stores/registry';
+import type {ComponentRecord, ComponentRecordType} from '../../src/main/resources/assets/js/page-editor/editor/types';
+
+//
+// * Helpers
+//
+
+function makeRecord(
+    path: string,
+    type: ComponentRecordType,
+    element: HTMLElement,
+    parentPath: string | undefined,
+    children: string[],
+    empty = false,
+): ComponentRecord {
+    return {
+        path: path === '/' ? ComponentPath.root() : ComponentPath.fromString(path),
+        type,
+        element,
+        parentPath,
+        children,
+        empty,
+        error: false,
+        descriptor: undefined,
+        loading: false,
+    };
+}
+
+function createMockPageView(element: HTMLElement) {
+    return {
+        getHTMLElement: () => element,
+        isLocked: () => false,
+        getSelectedView: () => undefined,
+        getLiveEditParams: () => ({contentId: 'storybook', isFragment: false, modifyPermissions: true}),
+        getComponentViewByPath: () => ({getContextMenuActions: () => []}),
+        getLockedMenuActions: () => [],
+    } as never;
+}
+
+//
+// * Styles
+//
+
+// Mimic the embedding site: a grid region that stretches its cell, plus a hostile
+// child-margin rule (verticalSpace-style) that would shift our injected boxes.
+const SITE_CSS = `
+.site-grid {
+    display: grid;
+    gap: 12px;
+    min-height: 120px;
+}
+.site-grid > * {
+    margin-top: 4!important;
+}
+`;
+
+//
+// * Story component
+//
+
+function EmptyRegionDropTarget() {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const mainRegionRef = useRef<HTMLElement>(null);
+
+    useEffect(() => {
+        const container = containerRef.current;
+        const mainRegion = mainRegionRef.current;
+        if (!container || !mainRegion) return undefined;
+
+        const records: Record<string, ComponentRecord> = {
+            '/': makeRecord('/', 'page', container, undefined, ['/main']),
+            '/main': makeRecord('/main', 'region', mainRegion, '/', [], true),
+        };
+
+        setCurrentPageView(createMockPageView(container));
+
+        // Only the drag placeholder portal is needed for this demo — the rest of
+        // the overlay chrome (DragPreview, highlighters) would render a stray
+        // cursor preview at the static x/y below.
+        const overlay = createOverlayHost(<DragPlaceholderPortal />);
+        setRegistry(records);
+        rebuildIndex(records);
+        setModifyAllowed(true);
+
+        const stopSync = initPlaceholderDragSync();
+        const stopGeometry = initGeometryTriggers();
+
+        // 1. Region is empty → RegionPlaceholder island is created in it.
+        syncPlaceholders(records);
+
+        // 2. Simulate a drag landing on the empty region: insert the drag anchor
+        //    and publish drag state targeting this region. DragPlaceholderPortal
+        //    mounts the DragPlaceholder into the anchor; the targetPath listener
+        //    re-syncs and (with the fix) destroys the now-redundant region host.
+        const regionRecord = getRecord('/main');
+        if (regionRecord) {
+            const anchor = ensurePlaceholderAnchor(undefined, regionRecord, 0);
+            setDragState({
+                itemType: 'part',
+                itemLabel: 'Part',
+                sourcePath: '/external-source',
+                targetPath: '/main',
+                dropAllowed: true,
+                message: undefined,
+                placeholderElement: anchor,
+                x: 0,
+                y: 0,
+            });
+        }
+
+        markDirty();
+
+        return () => {
+            stopGeometry();
+            stopSync();
+            setDragState(undefined);
+            overlay.unmount();
+            setRegistry({});
+            setCurrentPageView(undefined);
+        };
+    }, []);
+
+    return (
+        <div>
+            {/* biome-ignore lint/security/noDangerouslySetInnerHtml: story-only site CSS simulation */}
+            <style dangerouslySetInnerHTML={{__html: SITE_CSS}} />
+            <div
+                ref={containerRef}
+                data-testid="empty-region-canvas"
+                className="w-2xl rounded-xl border border-decorative bg-white p-5"
+            >
+                <section
+                    ref={mainRegionRef}
+                    className="site-grid"
+                    data-portal-region="main"
+                    data-testid="main-region"
+                />
+            </div>
+            <p className="mt-3 text-xs text-subtle">
+                Static snapshot — not interactive. Shows the drag placeholder filling an empty
+                region while that region is the active drop target.
+            </p>
+        </div>
+    );
+}
+
+//
+// * Meta
+//
+
+const meta = {
+    title: 'Page Editor/Drag',
+    parameters: {layout: 'centered'},
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const EmptyRegionTarget: Story = {
+    name: 'Drag / Empty Region Drop Target',
+    render: () => <EmptyRegionDropTarget />,
+};

--- a/.storybook/page-editor/integration.stories.tsx
+++ b/.storybook/page-editor/integration.stories.tsx
@@ -625,7 +625,10 @@ function LoadReplaceDemo() {
         const next = {
             ...current,
             '/main': {...parent, empty: false, children: [...parent.children, path]},
-            [path]: makeRecord(path, 'fragment', el, '/main', [], false),
+            // A freshly inserted component has no rendered HTML yet, so it is
+            // empty: a full LoadingPlaceholder block is shown while it loads
+            // (not the overlay shimmer, which is meant for reloading existing content).
+            [path]: makeRecord(path, 'fragment', el, '/main', [], true),
         };
         setRegistry(next);
         rebuildIndex(next);

--- a/src/main/resources/assets/js/page-editor/editor/adapter/placeholder-lifecycle.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/adapter/placeholder-lifecycle.tsx
@@ -32,8 +32,14 @@ function isRegionDraggedEmpty(record: ComponentRecord, dragState: DragState | un
     return record.children.every((childPath) => childPath === sourcePath);
 }
 
-function shouldShowPlaceholder(record: ComponentRecord, dragState: DragState | undefined): boolean {
+function shouldShowPlaceholder(path: string, record: ComponentRecord, dragState: DragState | undefined): boolean {
     if (record.type === 'page') return false;
+
+    // ? While a region is the active drop target, the drag placeholder (mounted
+    //   in its own anchor) is the sole occupant. Destroy the region placeholder
+    //   host so its empty box does not stack above the drag placeholder.
+    if (record.type === 'region' && dragState?.targetPath === path) return false;
+
     if (record.empty || record.error || record.loading) return true;
 
     return isRegionDraggedEmpty(record, dragState);
@@ -55,7 +61,7 @@ export function syncPlaceholders(records: Record<string, ComponentRecord>): void
     const nextPaths = new Set<string>();
 
     Object.entries(records).forEach(([path, record]) => {
-        if (!record.element || !shouldShowPlaceholder(record, dragState)) {
+        if (!record.element || !shouldShowPlaceholder(path, record, dragState)) {
             destroyPlaceholder(path);
             return;
         }
@@ -100,12 +106,15 @@ export function destroyPlaceholders(): void {
 
 export function initPlaceholderDragSync(): () => void {
     let lastSourcePath = $dragState.get()?.sourcePath;
+    let lastTargetPath = $dragState.get()?.targetPath;
 
     return $dragState.listen((state) => {
         const sourcePath = state?.sourcePath;
-        if (sourcePath === lastSourcePath) return;
+        const targetPath = state?.targetPath;
+        if (sourcePath === lastSourcePath && targetPath === lastTargetPath) return;
 
         lastSourcePath = sourcePath;
+        lastTargetPath = targetPath;
         syncPlaceholders(getRegistry());
     });
 }

--- a/src/main/resources/assets/js/page-editor/editor/adapter/reconcile.test.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/adapter/reconcile.test.tsx
@@ -105,6 +105,51 @@ describe('reconcilePage', () => {
         }
     });
 
+    it('destroys the region placeholder while the region is the active drop target', () => {
+        document.body.innerHTML = `
+            <section data-portal-region="main"></section>
+        `;
+
+        const stopDragSync = initPlaceholderDragSync();
+        const pageView = createPageView();
+
+        try {
+            reconcilePage(pageView as never);
+
+            const regionEl = document.querySelector('[data-portal-region="main"]') as HTMLElement;
+            const countHosts = () => Array.from(regionEl.children)
+                .filter((child) => child.hasAttribute(PLACEHOLDER_HOST_ATTR))
+                .length;
+
+            // Empty region shows its RegionPlaceholder island.
+            expect(countHosts()).toBe(1);
+
+            // Region becomes the active drop target — its placeholder host is
+            // destroyed so it cannot stack above the drag placeholder.
+            setDragState({
+                itemType: 'part',
+                itemLabel: 'Part',
+                sourcePath: '/external',
+                targetPath: '/main',
+                dropAllowed: true,
+                message: undefined,
+                placeholderElement: undefined,
+                x: undefined,
+                y: undefined,
+            });
+
+            expect(countHosts()).toBe(0);
+
+            // Target leaves the region — its placeholder host is restored.
+            setDragState(undefined);
+
+            expect(countHosts()).toBe(1);
+        } finally {
+            stopDragSync();
+            setDragState(undefined);
+        }
+    });
+
     it('does not show a region placeholder when other children remain visible', () => {
         document.body.innerHTML = `
             <section data-portal-region="main">

--- a/src/main/resources/assets/js/page-editor/editor/components/placeholders/RegionPlaceholder.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/components/placeholders/RegionPlaceholder.tsx
@@ -1,8 +1,5 @@
 import type {JSX} from 'preact';
 
-import {useStoreValue} from '../../hooks/use-store-value';
-import {$dragState} from '../../stores/registry';
-
 export type RegionPlaceholderProps = {
     path: string;
     regionName: string;
@@ -10,11 +7,7 @@ export type RegionPlaceholderProps = {
 
 const REGION_PLACEHOLDER_NAME = 'RegionPlaceholder';
 
-export const RegionPlaceholder = ({path}: RegionPlaceholderProps): JSX.Element | null => {
-    const dragState = useStoreValue($dragState);
-
-    if (dragState?.targetPath === path) return null;
-
+export const RegionPlaceholder = (_props: RegionPlaceholderProps): JSX.Element => {
     return (
         <div
             data-component={REGION_PLACEHOLDER_NAME}

--- a/src/main/resources/assets/js/page-editor/editor/interaction/drag/drop-positioning.test.ts
+++ b/src/main/resources/assets/js/page-editor/editor/interaction/drag/drop-positioning.test.ts
@@ -1,0 +1,26 @@
+import {ensurePlaceholderAnchor} from './drop-positioning';
+import {DRAG_ANCHOR_ATTR} from '../../constants';
+import type {ComponentRecord} from '../../types';
+
+describe('ensurePlaceholderAnchor', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('inserts an anchor with margin/padding forced to 0 !important', () => {
+        const regionEl = document.createElement('section');
+        document.body.appendChild(regionEl);
+        const regionRecord = {element: regionEl, children: []} as unknown as ComponentRecord;
+
+        const anchor = ensurePlaceholderAnchor(undefined, regionRecord, 0);
+
+        expect(anchor.getAttribute(DRAG_ANCHOR_ATTR)).toBe('true');
+        expect(anchor.parentElement).toBe(regionEl);
+
+        // Neutralizes the host page's child-spacing rules on the drag anchor.
+        expect(anchor.style.getPropertyValue('margin')).toMatch(/^0(px)?$/);
+        expect(anchor.style.getPropertyPriority('margin')).toBe('important');
+        expect(anchor.style.getPropertyValue('padding')).toMatch(/^0(px)?$/);
+        expect(anchor.style.getPropertyPriority('padding')).toBe('important');
+    });
+});

--- a/src/main/resources/assets/js/page-editor/editor/interaction/drag/drop-positioning.ts
+++ b/src/main/resources/assets/js/page-editor/editor/interaction/drag/drop-positioning.ts
@@ -110,6 +110,10 @@ export function ensurePlaceholderAnchor(
     const beforeElement = getDirectChildren(regionRecord, sourcePath)[targetIndex]?.element ?? null;
 
     anchor.setAttribute(DRAG_ANCHOR_ATTR, 'true');
+    // ! Anchor is a light-DOM child of the edited region; neutralize the host
+    //   page's child-spacing rules so the drag placeholder is not pushed off.
+    anchor.style.setProperty('margin', '0', 'important');
+    anchor.style.setProperty('padding', '0', 'important');
     regionElement.insertBefore(anchor, beforeElement);
 
     return anchor;

--- a/src/main/resources/assets/js/page-editor/editor/rendering/placeholder-island.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/rendering/placeholder-island.tsx
@@ -16,6 +16,12 @@ export function createPlaceholderIsland(
     const host = document.createElement('div');
     host.setAttribute(PLACEHOLDER_HOST_ATTR, options.overlay ? 'overlay' : 'true');
 
+    // ! The host is a light-DOM child of the edited page's region — shadow DOM
+    //   isolates its contents, not its own box. Force margin/padding to 0 so the
+    //   host page's child-spacing rules (e.g. `> * + *` margins) cannot shift it.
+    host.style.setProperty('margin', '0', 'important');
+    host.style.setProperty('padding', '0', 'important');
+
     let savedContainerPosition: string | undefined;
 
     if (options.overlay) {

--- a/src/main/resources/assets/js/page-editor/editor/rendering/rendering.test.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/rendering/rendering.test.tsx
@@ -27,6 +27,13 @@ describe('shadow rendering', () => {
         expect(island.shadow.querySelector('style[data-page-editor-ui]')).not.toBeNull();
         expect(island.shadow.textContent).toContain('Placeholder');
 
+        // The host is a light-DOM child of the edited page — its margin/padding
+        // are forced to 0 !important so host-page spacing rules cannot shift it.
+        expect(island.host.style.getPropertyValue('margin')).toMatch(/^0(px)?$/);
+        expect(island.host.style.getPropertyPriority('margin')).toBe('important');
+        expect(island.host.style.getPropertyValue('padding')).toMatch(/^0(px)?$/);
+        expect(island.host.style.getPropertyPriority('padding')).toBe('important');
+
         island.unmount();
         expect(container.querySelector('[data-pe-placeholder-host]')).toBeNull();
     });


### PR DESCRIPTION
Fixes the drag placeholder rendering far below an empty region's top.

- Destroy the region placeholder host while that region is the active drop target, so its empty box no longer stacks above the drag placeholder (`placeholder-lifecycle.tsx` re-syncs on `targetPath`; `RegionPlaceholder` no longer owns the null-on-target logic).
- Reset `margin`/`padding` to `0 !important` on placeholder hosts (`placeholder-island.tsx`) and the drag anchor (`drop-positioning.ts`) so the embedding page's child-spacing rules cannot shift them.
- Add regression tests (lifecycle destroy/restore, host and anchor style resets) and a `drag-empty-region` Storybook repro story.

Also includes a separate fix to the Load and Replace demo story: fresh components are inserted as empty so they show a full `LoadingPlaceholder` while loading, instead of an overlay shimmer over an empty element.

Closes #74

<sub>*Drafted with AI assistance*</sub>
