### PR TITLE
Drag placeholder collapses to its padding in shrink-to-fit regions #76

### DIFF
--- a/.storybook/page-editor/drag-empty-region.stories.tsx
+++ b/.storybook/page-editor/drag-empty-region.stories.tsx
@@ -1,4 +1,5 @@
 import type {Meta, StoryObj} from '@storybook/preact-vite';
+import {cn} from '@enonic/ui';
 import {ComponentPath} from '@enonic/lib-contentstudio/app/page/region/ComponentPath';
 import {useEffect, useRef} from 'preact/hooks';
 import {DragPlaceholderPortal} from '../../src/main/resources/assets/js/page-editor/editor/components/overlay/DragPlaceholderPortal';
@@ -64,6 +65,8 @@ function createMockPageView(element: HTMLElement) {
 
 // Mimic the embedding site: a grid region that stretches its cell, plus a hostile
 // child-margin rule (verticalSpace-style) that would shift our injected boxes.
+// `.site-flex` is a shrink-to-fit context — a flex row that sizes its child to
+// content, which is where an empty drop placeholder would collapse to its padding.
 const SITE_CSS = `
 .site-grid {
     display: grid;
@@ -73,13 +76,23 @@ const SITE_CSS = `
 .site-grid > * {
     margin-top: 4!important;
 }
+.site-flex {
+    display: flex;
+    gap: 12px;
+    min-height: 120px;
+}
 `;
 
 //
 // * Story component
 //
 
-function EmptyRegionDropTarget() {
+type EmptyRegionDropTargetProps = {
+    layout?: 'grid' | 'flex';
+    widthClassName?: string;
+};
+
+function EmptyRegionDropTarget({layout = 'grid', widthClassName = 'w-2xl'}: EmptyRegionDropTargetProps) {
     const containerRef = useRef<HTMLDivElement>(null);
     const mainRegionRef = useRef<HTMLElement>(null);
 
@@ -142,24 +155,34 @@ function EmptyRegionDropTarget() {
     }, []);
 
     return (
-        <div>
+        <div className="flex flex-col items-center max-w-120">
             {/* biome-ignore lint/security/noDangerouslySetInnerHtml: story-only site CSS simulation */}
             <style dangerouslySetInnerHTML={{__html: SITE_CSS}} />
             <div
                 ref={containerRef}
                 data-testid="empty-region-canvas"
-                className="w-2xl rounded-xl border border-decorative bg-white p-5"
+                className={cn(widthClassName, 'rounded-xl border border-decorative bg-white p-5')}
             >
                 <section
                     ref={mainRegionRef}
-                    className="site-grid"
+                    className={layout === 'flex' ? 'site-flex' : 'site-grid'}
                     data-portal-region="main"
                     data-testid="main-region"
                 />
             </div>
             <p className="mt-3 text-xs text-subtle">
-                Static snapshot — not interactive. Shows the drag placeholder filling an empty
-                region while that region is the active drop target.
+                {layout === 'flex' ? (
+                    <>
+                        Static snapshot — the region is a shrink-to-fit flex container. The drag placeholder keeps the
+                        same intrinsic width as the idle “Drop components here...” placeholder instead of collapsing to
+                        its padding.
+                    </>
+                ) : (
+                    <>
+                        Static snapshot — not interactive. Shows the drag placeholder filling an empty region while that
+                        region is the active drop target.
+                    </>
+                )}
             </p>
         </div>
     );
@@ -180,4 +203,9 @@ type Story = StoryObj<typeof meta>;
 export const EmptyRegionTarget: Story = {
     name: 'Drag / Empty Region Drop Target',
     render: () => <EmptyRegionDropTarget />,
+};
+
+export const EmptyRegionTargetShrinkToFit: Story = {
+    name: 'Drag / Empty Region (Shrink-to-fit)',
+    render: () => <EmptyRegionDropTarget layout="flex" widthClassName="w-80" />,
 };

--- a/src/main/resources/assets/js/page-editor/editor/components/placeholders/DragPlaceholder.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/components/placeholders/DragPlaceholder.tsx
@@ -10,8 +10,15 @@ const DRAG_PLACEHOLDER_NAME = 'DragPlaceholder';
 
 export const DragPlaceholder = ({className}: DragPlaceholderProps): JSX.Element => {
     return (
-        <div data-component={DRAG_PLACEHOLDER_NAME} className={cn('p-2.5', className)}>
-            <div className='pe-dash pe-dash-select min-h-25 bg-bdr-select/8' />
+        <div data-component={DRAG_PLACEHOLDER_NAME} className={cn('pe-shell select-none p-2.5', className)}>
+            <div className="pe-dash pe-dash-select flex min-h-25 items-center justify-center bg-bdr-select/8 px-4 py-2.5">
+                {/* Invisible copy of the idle prompt: reserves the same intrinsic width as
+                    RegionPlaceholder so a shrink-to-fit host region cannot squash the empty
+                    dropzone to its bare padding. pe-shell on the root gives it the matching font. */}
+                <p aria-hidden="true" className="invisible text-center text-subtle italic">
+                    {'Drop components here...'}
+                </p>
+            </div>
         </div>
     );
 };

--- a/src/main/resources/assets/js/page-editor/editor/components/placeholders/RegionPlaceholder.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/components/placeholders/RegionPlaceholder.tsx
@@ -11,11 +11,11 @@ export const RegionPlaceholder = (_props: RegionPlaceholderProps): JSX.Element =
     return (
         <div
             data-component={REGION_PLACEHOLDER_NAME}
-            className='pe-shell h-full overflow-hidden bg-surface-neutral select-none'
+            className="pe-shell h-full overflow-hidden bg-surface-neutral select-none"
         >
-            <div className='h-full p-2.5'>
-                <div className='pe-dash flex h-full min-h-25 items-center justify-center px-4 py-2.5'>
-                    <p className='text-center text-subtle italic'>Drop components here..</p>
+            <div className="h-full p-2.5">
+                <div className="pe-dash flex h-full min-h-25 items-center justify-center px-4 py-2.5">
+                    <p className="text-center text-subtle italic">Drop components here...</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
`DragPlaceholder` now carries an invisible, `aria-hidden` copy of the idle prompt inside a box matching `RegionPlaceholder`'s geometry, with `pe-shell` for matching font metrics. This reserves the same intrinsic width as the idle placeholder, so an empty drop target no longer collapses to its padding in shrink-to-fit host regions (flex rows, `inline-block`, `fit-content`). The drag preview self-heals because it measures the same anchor.

Added a `Drag / Empty Region (Shrink-to-fit)` Storybook story. Verified in Storybook: the shrink-to-fit flex region holds ~226px content width, while the full-width grid region still fills (no regression).

Closes #76

<sub>*Drafted with AI assistance*</sub>
