### PR TITLE
Add bundled lib dependencies to fix production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,8 @@
     "q": "^1.5.1"
   },
   "devDependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "@enonic/eslint-config": "^2.1.0",
     "@enonic/lib-admin-ui": "file:.xp/dev/lib-admin-ui",
     "@enonic/lib-contentstudio": "file:.xp/dev/lib-contentstudio",
@@ -93,11 +95,13 @@
     "@types/jquery": "^3.5.33",
     "@types/jqueryui": "^1.12.24",
     "@types/node": "^25.0.10",
+    "dayjs": "^1.11.20",
     "dompurify": "^3.4.0",
     "eslint": "^9.33.0",
     "globals": "^16.3.0",
     "jsdom": "^26.1.0",
     "lucide-preact": "^1.8.0",
+    "lucide-react": "^1.17.0",
     "mousetrap": "^1.6.5",
     "preact": "^10.29.1",
     "storybook": "~10.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,12 @@ importers:
         specifier: ^1.5.1
         version: 1.5.1
     devDependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@enonic/eslint-config':
         specifier: ^2.1.0
         version: 2.2.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(typescript-eslint@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(typescript@5.9.3)
@@ -66,6 +72,9 @@ importers:
       '@types/node':
         specifier: ^25.0.10
         version: 25.0.10
+      dayjs:
+        specifier: ^1.11.20
+        version: 1.11.20
       dompurify:
         specifier: ^3.4.0
         version: 3.4.1
@@ -81,6 +90,9 @@ importers:
       lucide-preact:
         specifier: ^1.8.0
         version: 1.8.0(preact@10.29.1)
+      lucide-react:
+        specifier: ^1.17.0
+        version: 1.17.0(react@19.2.4)
       mousetrap:
         specifier: ^1.6.5
         version: 1.6.5
@@ -211,7 +223,7 @@ packages:
     peerDependencies:
       '@dnd-kit/core': ^6.3.1
       '@dnd-kit/sortable': ^10.0.0
-      '@enonic/ui': ~1.0.0-beta.7
+      '@enonic/ui': ~1.0.0-beta.9
       '@radix-ui/react-slot': ^1.2.0
       focus-trap-react: ^11.0.0
       lucide-react: '>=0.500.0'


### PR DESCRIPTION
The production Vite build (`vite build --mode production`, run by gradle's `pnpmBuild`) failed to resolve `lucide-react` and other packages imported by the bundled `@enonic/lib-admin-ui` / `@enonic/lib-contentstudio` source. Those libs are aliased to their raw `.xp/dev` source, which has no own `node_modules`, and pnpm keeps their transitive deps only inside its store — unreachable when walking up from `.xp/dev`.

Declaring the four missing deps (`@dnd-kit/core`, `@dnd-kit/sortable`, `dayjs`, `lucide-react`) as devDependencies hoists them to the project root so the bundled source resolves them. They are build-time only (inlined into the dist) and should be removed once `@enonic/lib-admin-ui` / `@enonic/lib-contentstudio` are dropped.

We cannot use `workspace:*` in `package.json` yet, as we have to do Gradle's `pnpmPack` during build. All other options are also more complex. It's better to eagerly load all the dependencies as we do now and get rid of `lib-admin-ui` and `lib-contentsrudio` dependenies soon.

<sub>*Drafted with AI assistance*</sub>
