### PR TITLE
Localize hardcoded strings in the new Preact editor UI #79

### DIFF
--- a/src/main/resources/assets/js/page-editor/editor/components/overlay/context-menu/MenuHeader.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/components/overlay/context-menu/MenuHeader.tsx
@@ -1,6 +1,7 @@
-import {i18n} from '@enonic/lib-admin-ui/util/Messages';
 import {ContextMenu as UiContextMenu} from '@enonic/ui';
 import {Blocks, Box, Columns2, Globe, Lock, PenLine, Puzzle} from 'lucide-preact';
+
+import {useI18n} from '../../../i18n';
 
 import type {LucideIcon} from 'lucide-preact';
 import type {JSX} from 'preact';
@@ -25,11 +26,13 @@ export type MenuHeaderProps = {
 };
 
 export const MenuHeader = ({kind, type, name}: MenuHeaderProps): JSX.Element | null => {
+    const t = useI18n();
+
     if (kind === 'locked-page') {
         return (
             <UiContextMenu.Label className='flex w-full cursor-default items-center gap-2 py-2 font-bold'>
                 <Lock className='size-4 shrink-0' strokeWidth={2} />
-                <span className='min-w-0 flex-1 truncate'>Locked</span>
+                <span className='min-w-0 flex-1 truncate'>{t('live.view.page.locked')}</span>
             </UiContextMenu.Label>
         );
     }
@@ -39,7 +42,7 @@ export const MenuHeader = ({kind, type, name}: MenuHeaderProps): JSX.Element | n
     const Icon = TYPE_ICONS[type];
     if (Icon == null) return null;
 
-    const label = type === 'page' ? i18n('field.page') : (name || capitalize(type));
+    const label = type === 'page' ? t('field.page') : (name || capitalize(type));
 
     return (
         <UiContextMenu.Label className='flex w-full cursor-default items-center gap-2 py-2 font-bold'>

--- a/src/main/resources/assets/js/page-editor/editor/components/placeholders/ComponentPlaceholder.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/components/placeholders/ComponentPlaceholder.tsx
@@ -1,6 +1,8 @@
 import {cn} from '@enonic/ui';
 import {Box, Columns2, PenLine, Puzzle} from 'lucide-preact';
 
+import {useI18n} from '../../i18n';
+
 import type {ComponentRecordType} from '../../types';
 import type {LucideIcon} from 'lucide-preact';
 import type {CSSProperties, JSX} from 'preact';
@@ -44,6 +46,8 @@ const WireframeLines = ({className}: WireframeLinesProps): JSX.Element => (
 //
 
 export const ComponentPlaceholder = ({type, descriptor, error, bare = false, className, style}: ComponentPlaceholderProps): JSX.Element => {
+    const t = useI18n();
+
     if (error) {
         return (
             <div
@@ -59,7 +63,7 @@ export const ComponentPlaceholder = ({type, descriptor, error, bare = false, cla
                         )}
                     >
                         <p className='text-error'>
-                            {descriptor || 'This component could not be rendered.'}
+                            {descriptor || t('live.view.component.renderError')}
                         </p>
                     </div>
                 </div>

--- a/src/main/resources/assets/js/page-editor/editor/components/placeholders/DragPlaceholder.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/components/placeholders/DragPlaceholder.tsx
@@ -2,6 +2,8 @@ import {cn} from '@enonic/ui';
 
 import type {JSX} from 'preact';
 
+import {useI18n} from '../../i18n';
+
 export type DragPlaceholderProps = {
     className?: string;
 };
@@ -9,6 +11,8 @@ export type DragPlaceholderProps = {
 const DRAG_PLACEHOLDER_NAME = 'DragPlaceholder';
 
 export const DragPlaceholder = ({className}: DragPlaceholderProps): JSX.Element => {
+    const t = useI18n();
+
     return (
         <div data-component={DRAG_PLACEHOLDER_NAME} className={cn('pe-shell select-none p-2.5', className)}>
             <div className="pe-dash pe-dash-select flex min-h-25 items-center justify-center bg-bdr-select/8 px-4 py-2.5">
@@ -16,7 +20,7 @@ export const DragPlaceholder = ({className}: DragPlaceholderProps): JSX.Element 
                     RegionPlaceholder so a shrink-to-fit host region cannot squash the empty
                     dropzone to its bare padding. pe-shell on the root gives it the matching font. */}
                 <p aria-hidden="true" className="invisible text-center text-subtle italic">
-                    {'Drop components here...'}
+                    {t('live.view.region.drop')}
                 </p>
             </div>
         </div>

--- a/src/main/resources/assets/js/page-editor/editor/components/placeholders/RegionPlaceholder.tsx
+++ b/src/main/resources/assets/js/page-editor/editor/components/placeholders/RegionPlaceholder.tsx
@@ -1,5 +1,7 @@
 import type {JSX} from 'preact';
 
+import {useI18n} from '../../i18n';
+
 export type RegionPlaceholderProps = {
     path: string;
     regionName: string;
@@ -8,6 +10,8 @@ export type RegionPlaceholderProps = {
 const REGION_PLACEHOLDER_NAME = 'RegionPlaceholder';
 
 export const RegionPlaceholder = (_props: RegionPlaceholderProps): JSX.Element => {
+    const t = useI18n();
+
     return (
         <div
             data-component={REGION_PLACEHOLDER_NAME}
@@ -15,7 +19,7 @@ export const RegionPlaceholder = (_props: RegionPlaceholderProps): JSX.Element =
         >
             <div className="h-full p-2.5">
                 <div className="pe-dash flex h-full min-h-25 items-center justify-center px-4 py-2.5">
-                    <p className="text-center text-subtle italic">Drop components here...</p>
+                    <p className="text-center text-subtle italic">{t('live.view.region.drop')}</p>
                 </div>
             </div>
         </div>

--- a/src/main/resources/assets/js/page-editor/editor/i18n/index.ts
+++ b/src/main/resources/assets/js/page-editor/editor/i18n/index.ts
@@ -1,0 +1,2 @@
+export {EDITOR_PHRASES, type EditorPhraseKey} from './messages';
+export {useI18n, type Translate} from './use-i18n';

--- a/src/main/resources/assets/js/page-editor/editor/i18n/messages.ts
+++ b/src/main/resources/assets/js/page-editor/editor/i18n/messages.ts
@@ -1,0 +1,12 @@
+/**
+ * Editor-owned phrases with their English fallbacks. Content Studio supplies the
+ * real translations at runtime; until a key is added there, the fallback renders.
+ * This map doubles as the canonical list of keys to register in Content Studio.
+ */
+export const EDITOR_PHRASES = {
+    'live.view.region.drop': 'Drop components here...',
+    'live.view.component.renderError': 'This component could not be rendered.',
+    'live.view.page.locked': 'Locked',
+} as const;
+
+export type EditorPhraseKey = keyof typeof EDITOR_PHRASES;

--- a/src/main/resources/assets/js/page-editor/editor/i18n/use-i18n.ts
+++ b/src/main/resources/assets/js/page-editor/editor/i18n/use-i18n.ts
@@ -1,0 +1,26 @@
+import {Messages, i18n} from '@enonic/lib-admin-ui/util/Messages';
+
+import {EDITOR_PHRASES} from './messages';
+
+const FALLBACKS = new Map<string, string>(Object.entries(EDITOR_PHRASES));
+
+export type Translate = (key: string, ...args: unknown[]) => string;
+
+/**
+ * Resolve a phrase key: loaded Content Studio phrase → English fallback → `#key#`.
+ * Once Content Studio gains the key, it transparently overrides the fallback.
+ */
+const translate: Translate = (key, ...args) => {
+    if (Messages.hasMessage(key)) {
+        return i18n(key, ...args);
+    }
+    return FALLBACKS.get(key) ?? `#${key}#`;
+};
+
+/**
+ * Hook exposing the editor translate function. No context is needed — phrases live
+ * in the global lib-admin-ui Messages store, loaded before the Preact UI mounts.
+ */
+export function useI18n(): Translate {
+    return translate;
+}


### PR DESCRIPTION
Localizes the hardcoded English strings in the new Preact editor UI.

- Adds an `editor/i18n/` module: a `useI18n` hook over lib-admin-ui `Messages`/`i18n` with a central phrase map of English fallbacks under `live.view.*`
- Localizes the dropzone prompt, render-error message, and locked-page label in `RegionPlaceholder`, `DragPlaceholder`, `ComponentPlaceholder`, and `MenuHeader`
- Routes the existing `i18n('field.page')` call through the hook for one consistent pattern

Each string resolves to the loaded Content Studio phrase when present and falls back to the English default until the keys are registered in CS. Stories render correctly via the fallback with no changes needed.

Closes #79

<sub>*Drafted with AI assistance*</sub>
