### PR TITLE
Report component render errors in the LiveEdit ready event #85

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -54,7 +54,7 @@ the authoritative types live in `protocol/messages.ts`
 | Message                                           | Payload                            |
 | ------------------------------------------------- | ---------------------------------- |
 | `editor-loaded`                                   | `{}`                               |
-| `ready`                                           | `{}`                               |
+| `ready`                                           | `{errorPaths}`                     |
 | `init-error`                                      | `{message}`                        |
 | `component-selected`                              | `{path, position?, rightClicked?}` |
 | `component-deselected`                            | `{path?}`                          |
@@ -123,6 +123,11 @@ Behavioral guarantees consumers and contributors must preserve:
   `set-modify-allowed`, or the initial `params.locked`.
 - **`component-load-failed` carries `{message}`, not an `Error`.** No error
   instance crosses the frame boundary.
+- **`ready.errorPaths` is a full snapshot.** Every `ready` lists all components
+  whose markup rendered as an error placeholder
+  (`data-portal-placeholder-error`), possibly empty — the host replaces its
+  render-error state rather than merging. Failures of host-triggered loads
+  arrive incrementally via `component-load-failed` instead.
 - **Same-origin sessionStorage contract.** Selection/cursor state uses
   `contentstudio:liveedit:*` keys, shared with the host in same-origin
   embedding — keep the keys stable. Cross-origin embedding gets isolated (and

--- a/src/page-editor/editor/EditorBoot.test.ts
+++ b/src/page-editor/editor/EditorBoot.test.ts
@@ -1,0 +1,96 @@
+const bootMocks = vi.hoisted(() => ({
+    initNewUi: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('./init', () => ({
+    initNewUi: bootMocks.initNewUi,
+}));
+
+import type {ComponentRecord} from './types';
+
+import {createFakeBusPair, type FakeBusPair} from '../../test/fake-bus';
+import {ComponentPath, type InitializePayload} from '../protocol';
+import {EditorBoot} from './EditorBoot';
+import {setRegistry} from './stores/registry';
+
+function createRecord(path: string, error: boolean): ComponentRecord {
+    return {
+        path: ComponentPath.fromString(path),
+        type: 'part',
+        element: undefined,
+        parentPath: '/main',
+        children: [],
+        empty: false,
+        error,
+        descriptor: 'app:part',
+        loading: false,
+    };
+}
+
+const INIT_PAYLOAD: InitializePayload = {params: {contentId: 'content-id'}};
+
+describe('EditorBoot', () => {
+    let pair: FakeBusPair;
+    let boot: EditorBoot;
+
+    beforeEach(() => {
+        pair = createFakeBusPair();
+        boot = new EditorBoot(pair.editor);
+    });
+
+    afterEach(() => {
+        boot.destroy();
+        setRegistry({});
+        bootMocks.initNewUi.mockReset();
+        bootMocks.initNewUi.mockImplementation(() => vi.fn());
+    });
+
+    it('posts ready with the error paths parsed during boot', () => {
+        bootMocks.initNewUi.mockImplementation(() => {
+            setRegistry({
+                '/main/0': createRecord('/main/0', false),
+                '/main/1': createRecord('/main/1', true),
+                '/main/2': createRecord('/main/2', true),
+            });
+            return vi.fn();
+        });
+
+        const onReady = vi.fn();
+        pair.host.on('ready', onReady);
+
+        pair.host.post('initialize', INIT_PAYLOAD);
+
+        expect(onReady).toHaveBeenCalledTimes(1);
+        expect(onReady).toHaveBeenCalledWith({errorPaths: ['/main/1', '/main/2']});
+    });
+
+    it('posts ready with an empty snapshot when nothing failed to render', () => {
+        bootMocks.initNewUi.mockImplementation(() => {
+            setRegistry({'/main/0': createRecord('/main/0', false)});
+            return vi.fn();
+        });
+
+        const onReady = vi.fn();
+        pair.host.on('ready', onReady);
+
+        pair.host.post('initialize', INIT_PAYLOAD);
+
+        expect(onReady).toHaveBeenCalledWith({errorPaths: []});
+    });
+
+    it('posts init-error instead of ready when boot fails', () => {
+        bootMocks.initNewUi.mockImplementation(() => {
+            throw new Error('boom');
+        });
+
+        const onReady = vi.fn();
+        const onInitError = vi.fn();
+        pair.host.on('ready', onReady);
+        pair.host.on('init-error', onInitError);
+
+        pair.host.post('initialize', INIT_PAYLOAD);
+
+        expect(onReady).not.toHaveBeenCalled();
+        expect(onInitError).toHaveBeenCalledWith({message: expect.stringContaining('boom')});
+    });
+});

--- a/src/page-editor/editor/EditorBoot.ts
+++ b/src/page-editor/editor/EditorBoot.ts
@@ -12,6 +12,13 @@ import {initNewUi} from './init';
 import {setHostContext} from './stores/host';
 import {setPage} from './stores/page';
 import {setParams} from './stores/params';
+import {getRegistry} from './stores/registry';
+
+function collectErrorPaths(): string[] {
+    return Object.entries(getRegistry())
+        .filter(([, record]) => record.error)
+        .map(([path]) => path);
+}
 
 export class EditorBoot {
     private readonly bus: EditorBus;
@@ -56,7 +63,7 @@ export class EditorBoot {
             return;
         }
 
-        this.bus.post('ready', {});
+        this.bus.post('ready', {errorPaths: collectErrorPaths()});
     }
 
     destroy(): void {

--- a/src/page-editor/protocol/bus.test.ts
+++ b/src/page-editor/protocol/bus.test.ts
@@ -45,11 +45,16 @@ describe('PageEditorBus', () => {
             local: editorWindow,
         });
 
-        editor.post('ready', {});
+        editor.post('ready', {errorPaths: []});
 
         expect(hostWindow.posted).toEqual([
             {
-                message: {channel: PROTOCOL_CHANNEL, version: PROTOCOL_VERSION, type: 'ready', payload: {}},
+                message: {
+                    channel: PROTOCOL_CHANNEL,
+                    version: PROTOCOL_VERSION,
+                    type: 'ready',
+                    payload: {errorPaths: []},
+                },
                 targetOrigin: 'https://admin.example.com',
             },
         ]);
@@ -211,7 +216,7 @@ describe('PageEditorBus', () => {
         expect(second).not.toHaveBeenCalled();
 
         editor.destroy();
-        editor.post('ready', {});
+        editor.post('ready', {errorPaths: []});
         expect(hostWindow.posted.filter(entry => (entry.message as {type?: string}).type === 'ready')).toHaveLength(0);
     });
 });

--- a/src/page-editor/protocol/messages.ts
+++ b/src/page-editor/protocol/messages.ts
@@ -117,8 +117,11 @@ export type HostToEditorPayloads = {
 export type EditorToHostPayloads = {
     /** The iframe finished loading; the host may send `initialize`. */
     'editor-loaded': Record<string, never>;
-    /** The editor finished booting and parsed the page. */
-    ready: Record<string, never>;
+    /**
+     * The editor finished booting and parsed the page. `errorPaths` is the full
+     * snapshot of components whose markup rendered as an error placeholder.
+     */
+    ready: {errorPaths: string[]};
     'init-error': {message: string};
 
     'component-selected': {path: string; position?: ClickPosition; rightClicked?: boolean};


### PR DESCRIPTION
Extends the `ready` protocol message with `errorPaths` — a full snapshot of components whose markup rendered as an error placeholder (`data-portal-placeholder-error`), collected from the component registry in `EditorBoot` after boot. This lets the host learn about render failures already present in the server-rendered page; failures of host-triggered loads keep arriving incrementally via `component-load-failed`.

Closes #85

<sub>*Drafted with AI assistance*</sub>