### PR TITLE
Borders detection on drag is inconsistent #92

### DIFF
--- a/src/page-editor/editor/interaction/drag/component-drag.test.ts
+++ b/src/page-editor/editor/interaction/drag/component-drag.test.ts
@@ -523,6 +523,60 @@ describe('initComponentDrag', () => {
         expect(part.style.display).not.toBe('none');
     });
 
+    it('places the anchor before the first item when dragging upward within a block region', () => {
+        const region = document.createElement('section');
+        region.dataset.portalRegion = 'main';
+        const first = document.createElement('article');
+        first.dataset.portalComponentType = 'part';
+        const second = document.createElement('article');
+        second.dataset.portalComponentType = 'part';
+        region.append(first, second);
+        document.body.appendChild(region);
+
+        // Full-width flat sections in a block-flow region: with the dragged
+        // source excluded, only one (wide) sibling remains — the axis must stay
+        // vertical so the pointer's Y decides before/after the first item.
+        setRect(first, {top: 0, left: 0, width: 1000, height: 200});
+        setRect(second, {top: 200, left: 0, width: 1000, height: 200});
+
+        const records: Record<string, ComponentRecord> = {
+            '/main': createRecord('/main', region, 'region', ComponentPath.root().toString(), ['/main/0', '/main/1']),
+            '/main/0': createRecord('/main/0', first, 'part', '/main'),
+            '/main/1': createRecord('/main/1', second, 'part', '/main'),
+        };
+
+        setRegistry(records);
+        rebuildIndex(records);
+
+        // Pointer over the top half of the first component
+        vi.mocked(document.elementsFromPoint).mockReturnValue([first]);
+
+        const stop = initComponentDrag();
+
+        // Drag the second component upward; pointer X is right of the first
+        // item's horizontal midpoint so a mis-inferred 'x' axis would resolve
+        // to index 1 instead of 0.
+        dispatchMouseDown(second, 900, 250);
+        dispatchMouseMove(900, 40);
+
+        expect($dragState.get()).toMatchObject({
+            sourcePath: '/main/1',
+            targetPath: '/main',
+            dropAllowed: true,
+        });
+
+        const anchor = $dragState.get()?.placeholderElement;
+        expect(anchor?.parentElement).toBe(region);
+        expect(anchor?.nextElementSibling).toBe(first);
+
+        dispatchMouseUp(900, 40);
+
+        expect(calls('move-component-requested')).toHaveLength(1);
+        expect(calls('move-component-requested')[0].payload.to).toBe('/main/0');
+
+        stop();
+    });
+
     it('excludes source from insertion index when dragging within the same region', () => {
         const region = document.createElement('section');
         region.dataset.portalRegion = 'main';

--- a/src/page-editor/editor/interaction/drag/drop-positioning.test.ts
+++ b/src/page-editor/editor/interaction/drag/drop-positioning.test.ts
@@ -1,11 +1,38 @@
 import type {ComponentRecord} from '../../types';
 
+import {ComponentPath} from '../../../protocol';
 import {DRAG_ANCHOR_ATTR} from '../../constants';
-import {ensurePlaceholderAnchor} from './drop-positioning';
+import {setRegistry} from '../../stores/registry';
+import {ensurePlaceholderAnchor, inferAxis} from './drop-positioning';
+
+function setRect(
+    element: HTMLElement,
+    {top, left, width, height}: {top: number; left: number; width: number; height: number},
+): void {
+    Object.defineProperty(element, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => ({
+            top,
+            left,
+            width,
+            height,
+            right: left + width,
+            bottom: top + height,
+            x: left,
+            y: top,
+            toJSON: () => undefined,
+        }),
+    });
+}
+
+function createChildRecord(element: HTMLElement): ComponentRecord {
+    return {element} as unknown as ComponentRecord;
+}
 
 describe('ensurePlaceholderAnchor', () => {
     afterEach(() => {
         document.body.innerHTML = '';
+        setRegistry({});
     });
 
     it('inserts an anchor with margin/padding forced to 0 !important', () => {
@@ -23,5 +50,125 @@ describe('ensurePlaceholderAnchor', () => {
         expect(anchor.style.getPropertyPriority('margin')).toBe('important');
         expect(anchor.style.getPropertyValue('padding')).toMatch(/^0(px)?$/);
         expect(anchor.style.getPropertyPriority('padding')).toBe('important');
+    });
+
+    it('inserts the anchor beside a component wrapped in non-tracked markup', () => {
+        const regionEl = document.createElement('section');
+        const wrapper = document.createElement('div');
+        const component = document.createElement('article');
+        component.dataset.portalComponentType = 'part';
+        wrapper.appendChild(component);
+        regionEl.appendChild(wrapper);
+        document.body.appendChild(regionEl);
+
+        const records: Record<string, ComponentRecord> = {
+            '/main': {
+                path: ComponentPath.fromString('/main'),
+                type: 'region',
+                element: regionEl,
+                parentPath: ComponentPath.root().toString(),
+                children: ['/main/0'],
+                empty: false,
+                error: false,
+                descriptor: undefined,
+                loading: false,
+            },
+            '/main/0': {
+                path: ComponentPath.fromString('/main/0'),
+                type: 'part',
+                element: component,
+                parentPath: '/main',
+                children: [],
+                empty: true,
+                error: false,
+                descriptor: 'app:test',
+                loading: false,
+            },
+        };
+        setRegistry(records);
+
+        // The component is not a direct DOM child of the region; inserting into
+        // the region itself would throw NotFoundError.
+        const anchor = ensurePlaceholderAnchor(undefined, records['/main'], 0);
+
+        expect(anchor.parentElement).toBe(wrapper);
+        expect(anchor.nextElementSibling).toBe(component);
+    });
+});
+
+describe('inferAxis', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('uses flex direction for flex regions', () => {
+        const regionEl = document.createElement('section');
+        regionEl.style.display = 'flex';
+        regionEl.style.flexDirection = 'row';
+        document.body.appendChild(regionEl);
+
+        expect(inferAxis(regionEl, [])).toBe('x');
+
+        regionEl.style.flexDirection = 'column';
+        expect(inferAxis(regionEl, [])).toBe('y');
+    });
+
+    it('compares sibling offsets when at least two children exist', () => {
+        const regionEl = document.createElement('section');
+        const first = document.createElement('article');
+        const second = document.createElement('article');
+        regionEl.append(first, second);
+        document.body.appendChild(regionEl);
+
+        setRect(first, {top: 0, left: 0, width: 1000, height: 100});
+        setRect(second, {top: 100, left: 0, width: 1000, height: 100});
+        expect(inferAxis(regionEl, [createChildRecord(first), createChildRecord(second)])).toBe('y');
+
+        setRect(second, {top: 0, left: 1000, width: 1000, height: 100});
+        expect(inferAxis(regionEl, [createChildRecord(first), createChildRecord(second)])).toBe('x');
+    });
+
+    it('treats a lone full-width block child as vertical flow', () => {
+        const regionEl = document.createElement('section');
+        const child = document.createElement('article');
+        regionEl.appendChild(child);
+        document.body.appendChild(regionEl);
+
+        // Wide and flat — the aspect ratio must not flip the axis to 'x': the
+        // remaining sibling after excluding a dragged source is often full-width.
+        setRect(child, {top: 0, left: 0, width: 1000, height: 150});
+
+        expect(inferAxis(regionEl, [createChildRecord(child)])).toBe('y');
+    });
+
+    it('treats a lone inline-level child as horizontal flow', () => {
+        const regionEl = document.createElement('section');
+        const child = document.createElement('article');
+        child.style.display = 'inline-block';
+        regionEl.appendChild(child);
+        document.body.appendChild(regionEl);
+
+        setRect(child, {top: 0, left: 0, width: 200, height: 100});
+
+        expect(inferAxis(regionEl, [createChildRecord(child)])).toBe('x');
+    });
+
+    it('treats a lone floated child as horizontal flow', () => {
+        const regionEl = document.createElement('section');
+        const child = document.createElement('article');
+        child.style.cssFloat = 'left';
+        regionEl.appendChild(child);
+        document.body.appendChild(regionEl);
+
+        setRect(child, {top: 0, left: 0, width: 200, height: 100});
+
+        expect(inferAxis(regionEl, [createChildRecord(child)])).toBe('x');
+    });
+
+    it('defaults to vertical flow when there are no children', () => {
+        const regionEl = document.createElement('section');
+        document.body.appendChild(regionEl);
+
+        expect(inferAxis(regionEl, [])).toBe('y');
     });
 });

--- a/src/page-editor/editor/interaction/drag/drop-positioning.ts
+++ b/src/page-editor/editor/interaction/drag/drop-positioning.ts
@@ -44,9 +44,22 @@ export function inferAxis(regionElement: HTMLElement, childRecords: ComponentRec
         }
     }
 
-    if (childRecords[0]?.element) {
-        const rect = childRecords[0].element.getBoundingClientRect();
-        return rect.width > rect.height ? 'x' : 'y';
+    if (style.display.includes('grid')) {
+        return style.gridAutoFlow.startsWith('column') ? 'x' : 'y';
+    }
+
+    // ! A single child (e.g. the only sibling left after excluding the dragged
+    //   source) gives no offset to compare, and its aspect ratio says nothing
+    //   about flow direction — a full-width section is wide, yet the next
+    //   sibling still lands below it. Only inline-level or floated children
+    //   imply horizontal flow; everything else stacks vertically.
+    const childElement = childRecords[0]?.element;
+    if (childElement) {
+        const childStyle = window.getComputedStyle(childElement);
+        const floated = childStyle.cssFloat === 'left' || childStyle.cssFloat === 'right';
+        if (floated || childStyle.display.startsWith('inline')) {
+            return 'x';
+        }
     }
 
     return 'y';
@@ -118,7 +131,11 @@ export function ensurePlaceholderAnchor(
     //   page's child-spacing rules so the drag placeholder is not pushed off.
     anchor.style.setProperty('margin', '0', 'important');
     anchor.style.setProperty('padding', '0', 'important');
-    regionElement.insertBefore(anchor, beforeElement);
+    // ! Tracked components are not always direct DOM children of their region —
+    //   host markup may wrap them — so insert beside the component in its real
+    //   parent; `regionElement.insertBefore` throws for wrapped children.
+    const parentElement = beforeElement?.parentElement ?? regionElement;
+    parentElement.insertBefore(anchor, beforeElement);
 
     return anchor;
 }


### PR DESCRIPTION
Fixes inconsistent axis detection during drag that caused the drop placeholder to track pointer X and never move before the first or after the last item.

## Changes

- Fixed `inferAxis` child aspect-ratio fallback: with the dragged source excluded, a single wide sibling no longer flips the axis to horizontal
- Inferred vertical flow for a lone block-level child; only inline-level or floated children imply horizontal flow
- Added grid `grid-auto-flow` handling to `inferAxis`
- Made `ensurePlaceholderAnchor` insert beside components wrapped in non-tracked markup instead of throwing `NotFoundError` on `insertBefore`
- Added regression tests for `inferAxis`, wrapped-child anchoring, and dragging a component before the first item

Closes #92

<sub>*Drafted with AI assistance*</sub>
