### PR TITLE
Incorrect styling in the context menu #105

### DIFF
--- a/src/page-editor/editor/rendering/editor-ui.css
+++ b/src/page-editor/editor/rendering/editor-ui.css
@@ -3,7 +3,7 @@
 @import '@enonic/ui/preset.css';
 @import './editor-fonts.css';
 
-@source "../../../../../../../../node_modules/@enonic/ui";
+@source "../../../../node_modules/@enonic/ui";
 @source "../";
 
 /* Preset 0.47.7+ sets tokens + color + font-smoothing on :host — only extras here. */


### PR DESCRIPTION
The context menu (and other `@enonic/ui` components) rendered unstyled in consumer apps because utility classes used only inside `@enonic/ui` were missing from the inlined stylesheet — for example `px-4.5` on `ContextMenu.Item`.

Root cause: the Tailwind `@source` directive in `editor-ui.css` used 8 `../` levels — a depth carried over verbatim from the old XP-app layout (`src/main/resources/assets/js/page-editor/editor/rendering/`) — which in this standalone package resolves to a nonexistent `/node_modules/@enonic/ui`. Tailwind therefore never scanned the package, dropping every utility used only there (`px-4.5`, `gap-x-1.25`, `gap-x-2.5`, `h-11.5`, …) while keeping those that also appear in local `src`.

Corrected the depth to 4 `../` so it resolves to the repo-local `node_modules/@enonic/ui`, and documented the rationale so a future file move is caught rather than silently dropping styles. Verified in a fresh production build: the previously-missing rules are now generated (e.g. `.px-4\.5{padding-inline:calc(var(--spacing) * 4.5)}`), local classes remain intact, and `pnpm check` passes.

Closes #105

<sub>*Drafted with AI assistance*</sub>
