### PR TITLE
Missing locked mode when the document is not a live-edit render

### DIFF
--- a/src/page-editor/editor/EditorBoot.test.ts
+++ b/src/page-editor/editor/EditorBoot.test.ts
@@ -11,6 +11,7 @@ import type {ComponentRecord} from './types';
 import {createFakeBusPair, type FakeBusPair} from '../../test/fake-bus';
 import {ComponentPath, type InitializePayload} from '../protocol';
 import {EditorBoot} from './EditorBoot';
+import {$params} from './stores/params';
 import {setRegistry} from './stores/registry';
 
 function createRecord(path: string, error: boolean): ComponentRecord {
@@ -41,6 +42,9 @@ describe('EditorBoot', () => {
     afterEach(() => {
         boot.destroy();
         setRegistry({});
+        $params.set(undefined);
+        document.body.removeAttribute('data-portal-component-type');
+        document.body.innerHTML = '';
         bootMocks.initNewUi.mockReset();
         bootMocks.initNewUi.mockImplementation(() => vi.fn());
     });
@@ -92,5 +96,33 @@ describe('EditorBoot', () => {
 
         expect(onReady).not.toHaveBeenCalled();
         expect(onInitError).toHaveBeenCalledWith({message: expect.stringContaining('boom')});
+    });
+
+    it('keeps params.locked when the body is a page-engine render', () => {
+        document.body.setAttribute('data-portal-component-type', 'page');
+
+        pair.host.post('initialize', {params: {contentId: 'page-content', locked: false}});
+
+        expect($params.get()?.locked).toBe(false);
+    });
+
+    it('forces params.locked when the document has no live-edit markup', () => {
+        pair.host.post('initialize', {params: {contentId: 'mapped-content', locked: false}});
+
+        expect($params.get()?.locked).toBe(true);
+    });
+
+    it('forces params.locked for a fragment page without a rendered fragment component', () => {
+        pair.host.post('initialize', {params: {contentId: 'fragment-content', isFragment: true, locked: false}});
+
+        expect($params.get()?.locked).toBe(true);
+    });
+
+    it('keeps params.locked for a fragment page with a rendered fragment component', () => {
+        document.body.innerHTML = '<div data-portal-component-type="part"></div>';
+
+        pair.host.post('initialize', {params: {contentId: 'fragment-content', isFragment: true, locked: false}});
+
+        expect($params.get()?.locked).toBe(false);
     });
 });

--- a/src/page-editor/editor/EditorBoot.ts
+++ b/src/page-editor/editor/EditorBoot.ts
@@ -5,10 +5,12 @@
  * handled once in `bus-adapter.ts`.
  */
 
-import type {EditorBus, InitializePayload} from '../protocol';
+import type {EditorBus, InitializePayload, PageEditorParams} from '../protocol';
 
+import {COMPONENT_SELECTOR} from './constants';
 import {addPhrases} from './i18n';
 import {initNewUi} from './init';
+import {isComponentElement} from './parse/parse-page';
 import {setHostContext} from './stores/host';
 import {setPage} from './stores/page';
 import {setParams} from './stores/params';
@@ -18,6 +20,19 @@ function collectErrorPaths(): string[] {
     return Object.entries(getRegistry())
         .filter(([, record]) => record.error)
         .map(([path]) => path);
+}
+
+// A body without live-edit markup was not rendered by the page engine — e.g. a
+// controller mapping matched the request in edit mode — so it cannot be edited.
+function isLiveEditRender(body: HTMLElement, isFragment: boolean): boolean {
+    return isFragment ? body.querySelector(COMPONENT_SELECTOR) != null : isComponentElement(body);
+}
+
+function resolveParams(params: PageEditorParams): PageEditorParams {
+    return {
+        ...params,
+        locked: params.locked === true || !isLiveEditRender(document.body, params.isFragment === true),
+    };
 }
 
 export class EditorBoot {
@@ -52,7 +67,7 @@ export class EditorBoot {
         });
 
         addPhrases(payload.phrases ?? {});
-        setParams(payload.params);
+        setParams(resolveParams(payload.params));
         setPage(payload.page ?? undefined);
 
         try {


### PR DESCRIPTION
The fix is released in 2.0.1-beta.2 and can be tested in https://github.com/enonic/app-contentstudio/pull/11148